### PR TITLE
chore: streamline and align .env.example placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,51 +1,34 @@
-# ── App ───────────────────────────────────────────────────────────────────────
+# App
 APP_BIND_ADDR=127.0.0.1:3000
 APP_BASE_URL=http://localhost:3000
-# Any string — a 64-char random hex is ideal. SHA-512 is used to derive the
-# cookie signing key, so length is not a hard requirement.
-# Generate one with: openssl rand -hex 32
-APP_SESSION_SECRET=change-me-to-a-long-random-secret
+APP_SESSION_SECRET=replace-with-hex-secret
 APP_REQUIRED_ADMIN_ROLE=matrix-admin
 HOMESERVER_DOMAIN=example.com
 
-# ── OIDC (Keycloak login for the admin app itself) ────────────────────────────
+# OIDC (Keycloak realm)
 OIDC_ISSUER_URL=https://keycloak.example.com/realms/matrix
-OIDC_CLIENT_ID=matrix-identity-admin
-OIDC_CLIENT_SECRET=your-oidc-client-secret
+OIDC_CLIENT_ID=matrix-admin-ui
+OIDC_CLIENT_SECRET=replace-with-oidc-client-secret
 OIDC_REDIRECT_URL=http://localhost:3000/auth/callback
 
-# ── Keycloak Admin API ────────────────────────────────────────────────────────
+# Keycloak admin client
 KEYCLOAK_BASE_URL=https://keycloak.example.com
 KEYCLOAK_REALM=matrix
-# Service account with view-users role from realm-management
-KEYCLOAK_ADMIN_CLIENT_ID=matrix-identity-admin-service
-KEYCLOAK_ADMIN_CLIENT_SECRET=your-keycloak-service-account-secret
+KEYCLOAK_ADMIN_CLIENT_ID=matrix-admin-service
+KEYCLOAK_ADMIN_CLIENT_SECRET=replace-with-keycloak-admin-secret
 
-# ── MAS (Matrix Authentication Service) Admin API ────────────────────────────
-# Include the path prefix if MAS is served under a subpath (common when proxied
-# behind Synapse). API calls are made to {MAS_BASE_URL}/api/admin/v1/...
-# Example with subpath:  https://matrix.example.com/auth
-# Example standalone:    https://mas.example.com
-#
-# Uses OAuth2 client credentials (grant_type=client_credentials, scope=urn:mas:admin).
-# Create a client in MAS with the admin scope and paste its ID/secret here.
+# MAS admin OAuth2 client
 MAS_BASE_URL=https://matrix.example.com/auth
-MAS_ADMIN_CLIENT_ID=your-mas-admin-client-id
-MAS_ADMIN_CLIENT_SECRET=your-mas-admin-client-secret
+MAS_ADMIN_CLIENT_ID=matrix-admin
+MAS_ADMIN_CLIENT_SECRET=replace-with-mas-admin-secret
 
-# ── Database ──────────────────────────────────────────────────────────────────
-# SQLite (default). Use an absolute path or a path relative to where the binary runs.
-# The data/ directory is created automatically if missing.
+# Local audit database
 DATABASE_URL=sqlite://data/app.db
 
-# ── Bot invite API ────────────────────────────────────────────────────────────
-# Shared secret the maubot plugin sends as: Authorization: Bearer <secret>
-# Generate one with: openssl rand -hex 32
-BOT_API_SECRET=change-me-to-a-long-random-secret
+# Bot invite API
+BOT_API_SECRET=replace-with-bot-api-secret
+# Optional comma-separated domain allowlist, e.g. "example.com,example.org"
+INVITE_ALLOWED_DOMAINS=
 
-# Optional: comma-separated list of allowed email domains for invites.
-# Unset (default) permits any domain — appropriate for friends/family with personal emails.
-# INVITE_ALLOWED_DOMAINS=company.com,contractor.company.com
-
-# ── Logging ───────────────────────────────────────────────────────────────────
+# Logging
 RUST_LOG=info


### PR DESCRIPTION
### Motivation
- Simplify and clarify the `.env.example` template so it is concise, copy/paste-ready, and uses explicit `replace-with-*` placeholders aligned to the app and MAS admin client naming.

### Description
- Replace and condense the existing `.env.example` content to clearer sections and concise defaults, update placeholder values (e.g. `APP_SESSION_SECRET`, `OIDC_CLIENT_ID`, `KEYCLOAK_ADMIN_CLIENT_ID`, `MAS_ADMIN_CLIENT_ID`, `BOT_API_SECRET`) and include the optional `INVITE_ALLOWED_DOMAINS` line.

### Testing
- Ran `cargo check` and `cargo check -q`, which completed successfully; ran `cargo test` (all tests passed); ran `cargo clippy --all-targets --all-features`, which completed successfully; ran `cargo fmt -- --check`, which passed; `cargo audit` was not available in the environment so dependency CVE scanning was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdaa9b3288321b75cd2bc6f0243e1)