### PR TITLE
feat(users): delete user from Keycloak and MAS

### DIFF
--- a/src/clients/keycloak.rs
+++ b/src/clients/keycloak.rs
@@ -21,6 +21,8 @@ pub trait KeycloakApi: Send + Sync {
     async fn create_user(&self, username: &str, email: &str) -> Result<String, AppError>;
     /// Trigger Keycloak to email the user a set-password + verify-email link.
     async fn send_invite_email(&self, user_id: &str) -> Result<(), AppError>;
+    /// Permanently delete a user from Keycloak.
+    async fn delete_user(&self, user_id: &str) -> Result<(), AppError>;
 }
 
 struct CachedToken {
@@ -291,6 +293,22 @@ impl KeycloakApi for KeycloakClient {
             .put(&url)
             .bearer_auth(&token)
             .json(&["UPDATE_PASSWORD", "UPDATE_PROFILE", "VERIFY_EMAIL"])
+            .send()
+            .await
+            .map_err(|e| upstream_error("keycloak", e))?
+            .error_for_status()
+            .map_err(|e| upstream_error("keycloak", e))?;
+
+        Ok(())
+    }
+
+    async fn delete_user(&self, user_id: &str) -> Result<(), AppError> {
+        let token = self.admin_token().await?;
+        let url = self.admin_url(&format!("/users/{user_id}"));
+
+        self.http
+            .delete(&url)
+            .bearer_auth(&token)
             .send()
             .await
             .map_err(|e| upstream_error("keycloak", e))?

--- a/src/clients/mas.rs
+++ b/src/clients/mas.rs
@@ -22,6 +22,8 @@ pub trait MasApi: Send + Sync {
     async fn list_sessions(&self, mas_user_id: &str) -> Result<Vec<MasSession>, AppError>;
     /// Finish a session. `session_type` must be "compat" or "oauth2".
     async fn finish_session(&self, session_id: &str, session_type: &str) -> Result<(), AppError>;
+    /// Permanently delete a MAS user by their MAS ULID.
+    async fn delete_user(&self, mas_user_id: &str) -> Result<(), AppError>;
 }
 
 // ── JSON:API response structs (internal to this module) ───────────────────────
@@ -204,6 +206,22 @@ impl MasApi for MasClient {
 
         self.http
             .post(self.url(&path))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| upstream_error("mas", e))?
+            .error_for_status()
+            .map_err(|e| upstream_error("mas", e))?;
+
+        Ok(())
+    }
+
+    async fn delete_user(&self, mas_user_id: &str) -> Result<(), AppError> {
+        let token = self.admin_token().await?;
+        let url = self.url(&format!("/api/admin/v1/users/{mas_user_id}"));
+
+        self.http
+            .delete(&url)
             .bearer_auth(&token)
             .send()
             .await

--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -1,0 +1,105 @@
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Redirect},
+    Form,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{
+    auth::{csrf::validate, session::AuthenticatedAdmin},
+    error::AppError,
+    models::audit::AuditResult,
+    state::AppState,
+};
+
+#[derive(Deserialize)]
+pub struct DeleteUserForm {
+    pub _csrf: String,
+}
+
+/// POST /users/{id}/delete
+///
+/// Deletes the user from both Keycloak and MAS (if a MAS account exists).
+/// MAS is attempted first so that if it fails the Keycloak record is preserved
+/// and the admin can retry. Both deletions are audit-logged.
+pub async fn delete_user(
+    AuthenticatedAdmin(admin): AuthenticatedAdmin,
+    State(state): State<AppState>,
+    Path(keycloak_id): Path<String>,
+    Form(form): Form<DeleteUserForm>,
+) -> Result<impl IntoResponse, AppError> {
+    validate(&admin.csrf_token, &form._csrf)?;
+
+    // Resolve username and MAS ID before deleting anything.
+    let kc_user = state.keycloak.get_user(&keycloak_id).await?;
+    let username = kc_user.username.clone();
+    let matrix_user_id = format!("@{}:{}", username, state.config.homeserver_domain);
+
+    let mas_user = state
+        .mas
+        .get_user_by_username(&username)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "MAS user lookup failed during delete");
+            None
+        });
+
+    // ── Delete MAS user first (if present) ───────────────────────────────────
+    if let Some(ref mas) = mas_user {
+        let mas_result = state.mas.delete_user(&mas.id).await;
+        let audit_result = if mas_result.is_ok() {
+            AuditResult::Success
+        } else {
+            AuditResult::Failure
+        };
+
+        state
+            .audit
+            .log(
+                &admin.subject,
+                &admin.username,
+                Some(&keycloak_id),
+                Some(&matrix_user_id),
+                "delete_mas_user",
+                audit_result,
+                json!({
+                    "keycloak_user_id": keycloak_id,
+                    "mas_user_id": mas.id,
+                    "username": username,
+                }),
+            )
+            .await?;
+
+        mas_result?;
+    }
+
+    // ── Delete Keycloak user ──────────────────────────────────────────────────
+    let kc_result = state.keycloak.delete_user(&keycloak_id).await;
+    let audit_result = if kc_result.is_ok() {
+        AuditResult::Success
+    } else {
+        AuditResult::Failure
+    };
+
+    state
+        .audit
+        .log(
+            &admin.subject,
+            &admin.username,
+            Some(&keycloak_id),
+            Some(&matrix_user_id),
+            "delete_keycloak_user",
+            audit_result,
+            json!({
+                "keycloak_user_id": keycloak_id,
+                "username": username,
+                "mas_deleted": mas_user.is_some(),
+            }),
+        )
+        .await?;
+
+    kc_result?;
+
+    Ok(Redirect::to("/users/search"))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit;
 pub mod auth;
 pub mod dashboard;
+pub mod delete;
 pub mod devices;
 pub mod invite;
 pub mod sessions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,16 +97,17 @@ async fn main() {
         .route("/", get(handlers::dashboard::dashboard))
         // User search & detail
         .route("/users/search", get(handlers::users::search))
-        .route("/users/:id", get(handlers::users::detail))
+        .route("/users/{id}", get(handlers::users::detail))
         // Mutations (all POST, CSRF-protected)
         .route(
-            "/users/:id/sessions/:session_id/revoke",
+            "/users/{id}/sessions/{session_id}/revoke",
             post(handlers::sessions::revoke),
         )
         .route(
-            "/users/:id/keycloak/logout",
+            "/users/{id}/keycloak/logout",
             post(handlers::devices::force_keycloak_logout),
         )
+        .route("/users/{id}/delete", post(handlers::delete::delete_user))
         // Bot invite API (bearer-token authenticated, no CSRF)
         .route("/api/v1/invites", post(handlers::invite::create_invite))
         // Audit log

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -184,6 +184,9 @@ mod tests {
         async fn send_invite_email(&self, _user_id: &str) -> Result<(), AppError> {
             Ok(())
         }
+        async fn delete_user(&self, _user_id: &str) -> Result<(), AppError> {
+            Ok(())
+        }
     }
 
     struct MockMas {
@@ -204,6 +207,9 @@ mod tests {
             _session_id: &str,
             _session_type: &str,
         ) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn delete_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
             Ok(())
         }
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -103,6 +103,10 @@ impl KeycloakApi for MockKeycloak {
             Ok(())
         }
     }
+
+    async fn delete_user(&self, _user_id: &str) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 // ── Mock MAS ──────────────────────────────────────────────────────────────────
@@ -124,6 +128,10 @@ impl MasApi for MockMas {
     }
 
     async fn finish_session(&self, _session_id: &str, _session_type: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn delete_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
         Ok(())
     }
 }

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -41,6 +41,13 @@
     <input type="hidden" name="_csrf" value="{{ csrf_token }}">
     <button type="submit" class="btn btn-danger">Force Keycloak Logout</button>
   </form>
+
+  <!-- Delete user -->
+  <form method="post" action="/users/{{ user.keycloak_id }}/delete" style="margin-top:0.5rem"
+        onsubmit="return confirm('Permanently delete {{ user.username }} from Keycloak and MAS? This cannot be undone.')">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+    <button type="submit" class="btn btn-danger">Delete User</button>
+  </form>
 </div>
 
 <!-- Sessions -->


### PR DESCRIPTION
## Summary

- Adds a **Delete User** button to the user detail page
- Deletes the account from both Keycloak and MAS in a single admin action
- MAS is deleted first — if it fails, the Keycloak record is preserved so the admin can retry
- Both operations are individually audit-logged with full metadata
- Redirects to user search on success

## Motivation

When a Keycloak user is deleted (e.g. during invite testing), MAS retains the account and blocks re-inviting the same email with "email already in use". This makes cleanup a manual database operation. The new action handles it atomically from the admin UI.

## Test plan

- [ ] Delete a user who has both a Keycloak account and a MAS account — verify both are removed and audit log shows two entries
- [ ] Delete a user who only has a Keycloak account (no MAS record) — verify Keycloak deletion succeeds and no MAS audit entry is written
- [ ] Re-invite the deleted email — verify the invite flow completes without "email already in use" from MAS
- [ ] Verify the confirmation dialog appears before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)