### PR TITLE
test(handlers): add handler-level tests for all mutation endpoints

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -103,3 +103,187 @@ pub async fn delete_user(
 
     Ok(Redirect::to("/users/search"))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use crate::{
+        models::{keycloak::KeycloakUser, mas::MasUser},
+        test_helpers::{
+            build_test_state_full, make_auth_cookie, mutations_router, MockKeycloak, MockMas,
+            TEST_CSRF,
+        },
+    };
+
+    fn test_kc_user() -> KeycloakUser {
+        KeycloakUser {
+            id: "kc-123".to_string(),
+            username: "testuser".to_string(),
+            email: Some("test@example.com".to_string()),
+            first_name: None,
+            last_name: None,
+            enabled: true,
+            email_verified: true,
+            created_timestamp: None,
+        }
+    }
+
+    fn test_mas_user() -> MasUser {
+        MasUser {
+            id: "mas-456".to_string(),
+            username: "testuser".to_string(),
+        }
+    }
+
+    async fn post_delete(
+        state: crate::state::AppState,
+        user_id: &str,
+        csrf: &str,
+        auth_cookie: Option<&str>,
+    ) -> axum::response::Response {
+        let body = format!("_csrf={csrf}");
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/users/{user_id}/delete"))
+            .header("content-type", "application/x-www-form-urlencoded");
+        if let Some(cookie) = auth_cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        mutations_router(state)
+            .oneshot(builder.body(Body::from(body)).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn delete_with_mas_account_redirects_to_search() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas {
+                user: Some(test_mas_user()),
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/users/search");
+    }
+
+    #[tokio::test]
+    async fn delete_without_mas_account_redirects_to_search() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/users/search");
+    }
+
+    #[tokio::test]
+    async fn delete_keycloak_user_not_found_returns_404() {
+        let state = build_test_state_full(
+            MockKeycloak::default(), // no users → get_user returns NotFound
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "nonexistent", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_invalid_csrf_returns_400() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", "wrong-csrf", Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn delete_unauthenticated_redirects_to_login() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        // No cookie → AuthenticatedAdmin redirects to /auth/login
+        let resp = post_delete(state, "kc-123", TEST_CSRF, None).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn delete_mas_failure_aborts_before_keycloak_returns_502() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas {
+                user: Some(test_mas_user()),
+                fail_delete_user: true,
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn delete_keycloak_failure_returns_502() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                fail_delete: true,
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/src/handlers/devices.rs
+++ b/src/handlers/devices.rs
@@ -50,3 +50,84 @@ pub async fn force_keycloak_logout(
 
     Ok(Redirect::to(&format!("/users/{keycloak_id}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use crate::test_helpers::{
+        build_test_state_full, make_auth_cookie, mutations_router, MockKeycloak, MockMas, TEST_CSRF,
+    };
+
+    async fn post_force_logout(
+        state: crate::state::AppState,
+        user_id: &str,
+        csrf: &str,
+        auth_cookie: Option<&str>,
+    ) -> axum::response::Response {
+        let body = format!("_csrf={csrf}");
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/users/{user_id}/keycloak/logout"))
+            .header("content-type", "application/x-www-form-urlencoded");
+        if let Some(cookie) = auth_cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        mutations_router(state)
+            .oneshot(builder.body(Body::from(body)).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn force_logout_success_redirects_to_user_page() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_force_logout(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/users/kc-123");
+    }
+
+    #[tokio::test]
+    async fn force_logout_invalid_csrf_returns_400() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_force_logout(state, "kc-123", "wrong-csrf", Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn force_logout_unauthenticated_redirects_to_login() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let resp = post_force_logout(state, "kc-123", TEST_CSRF, None).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn force_logout_keycloak_failure_returns_502() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                fail_logout: true,
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_force_logout(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -58,3 +58,128 @@ pub async fn revoke(
 
     Ok(Redirect::to(&format!("/users/{keycloak_id}")))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use crate::test_helpers::{
+        build_test_state_full, make_auth_cookie, mutations_router, MockKeycloak, MockMas, TEST_CSRF,
+    };
+
+    async fn post_revoke(
+        state: crate::state::AppState,
+        user_id: &str,
+        session_id: &str,
+        csrf: &str,
+        session_type: &str,
+        auth_cookie: Option<&str>,
+    ) -> axum::response::Response {
+        let body = format!("_csrf={csrf}&session_type={session_type}");
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/users/{user_id}/sessions/{session_id}/revoke"))
+            .header("content-type", "application/x-www-form-urlencoded");
+        if let Some(cookie) = auth_cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        mutations_router(state)
+            .oneshot(builder.body(Body::from(body)).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn revoke_success_redirects_to_user_page() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_revoke(
+            state,
+            "kc-123",
+            "sess-1",
+            TEST_CSRF,
+            "compat",
+            Some(&cookie),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/users/kc-123");
+    }
+
+    #[tokio::test]
+    async fn revoke_invalid_csrf_returns_400() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_revoke(
+            state,
+            "kc-123",
+            "sess-1",
+            "wrong-csrf",
+            "compat",
+            Some(&cookie),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn revoke_unauthenticated_redirects_to_login() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let resp = post_revoke(state, "kc-123", "sess-1", TEST_CSRF, "compat", None).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn revoke_mas_failure_returns_502() {
+        let state = build_test_state_full(
+            MockKeycloak::default(),
+            MockMas {
+                fail_finish_session: true,
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_revoke(
+            state,
+            "kc-123",
+            "sess-1",
+            TEST_CSRF,
+            "compat",
+            Some(&cookie),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn revoke_oauth2_session_type_succeeds() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_revoke(
+            state,
+            "kc-123",
+            "sess-1",
+            TEST_CSRF,
+            "oauth2",
+            Some(&cookie),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    }
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -7,6 +7,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 
 use crate::{
     auth::oidc::OidcClient,
+    auth::session::AdminSession,
     clients::{KeycloakApi, MasApi},
     config::{Config, KeycloakConfig, MasConfig, OidcConfig},
     error::AppError,
@@ -18,6 +19,16 @@ use crate::{
     state::AppState,
 };
 
+// ── Test constants ────────────────────────────────────────────────────────────
+
+/// Fixed 64-byte key used for cookie encryption in tests.
+/// All test state builders use this key so that `make_auth_cookie` can
+/// produce cookies that the handlers will accept.
+pub const TEST_KEY: &[u8; 64] = &[42u8; 64];
+
+/// CSRF token used in test sessions and form bodies.
+pub const TEST_CSRF: &str = "test-csrf-token";
+
 // ── Mock Keycloak ─────────────────────────────────────────────────────────────
 
 /// Configurable mock for the Keycloak API.
@@ -25,7 +36,7 @@ use crate::{
 /// Defaults to returning empty/successful responses. Set fields to control
 /// behaviour in individual tests.
 pub struct MockKeycloak {
-    /// Users returned by `search_users`.
+    /// Users returned by `search_users` and `get_user` (first element).
     pub users: Vec<KeycloakUser>,
     pub groups: Vec<KeycloakGroup>,
     pub roles: Vec<KeycloakRole>,
@@ -37,6 +48,10 @@ pub struct MockKeycloak {
     pub fail_create: bool,
     /// If true, `send_invite_email` returns an upstream error.
     pub fail_send_invite: bool,
+    /// If true, `logout_user` returns an upstream error.
+    pub fail_logout: bool,
+    /// If true, `delete_user` returns an upstream error.
+    pub fail_delete: bool,
 }
 
 impl Default for MockKeycloak {
@@ -49,6 +64,8 @@ impl Default for MockKeycloak {
             create_user_id: "new-kc-id".to_string(),
             fail_create: false,
             fail_send_invite: false,
+            fail_logout: false,
+            fail_delete: false,
         }
     }
 }
@@ -79,7 +96,14 @@ impl KeycloakApi for MockKeycloak {
     }
 
     async fn logout_user(&self, _user_id: &str) -> Result<(), AppError> {
-        Ok(())
+        if self.fail_logout {
+            Err(AppError::Upstream {
+                service: "keycloak".into(),
+                message: "mock logout failure".into(),
+            })
+        } else {
+            Ok(())
+        }
     }
 
     async fn create_user(&self, _username: &str, _email: &str) -> Result<String, AppError> {
@@ -105,7 +129,14 @@ impl KeycloakApi for MockKeycloak {
     }
 
     async fn delete_user(&self, _user_id: &str) -> Result<(), AppError> {
-        Ok(())
+        if self.fail_delete {
+            Err(AppError::Upstream {
+                service: "keycloak".into(),
+                message: "mock delete_user failure".into(),
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -115,6 +146,10 @@ impl KeycloakApi for MockKeycloak {
 pub struct MockMas {
     pub user: Option<MasUser>,
     pub sessions: Vec<MasSession>,
+    /// If true, `finish_session` returns an upstream error.
+    pub fail_finish_session: bool,
+    /// If true, `delete_user` returns an upstream error.
+    pub fail_delete_user: bool,
 }
 
 #[async_trait]
@@ -128,22 +163,38 @@ impl MasApi for MockMas {
     }
 
     async fn finish_session(&self, _session_id: &str, _session_type: &str) -> Result<(), AppError> {
-        Ok(())
+        if self.fail_finish_session {
+            Err(AppError::Upstream {
+                service: "mas".into(),
+                message: "mock finish_session failure".into(),
+            })
+        } else {
+            Ok(())
+        }
     }
 
     async fn delete_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
-        Ok(())
+        if self.fail_delete_user {
+            Err(AppError::Upstream {
+                service: "mas".into(),
+                message: "mock delete_user failure".into(),
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 
-// ── State builder ─────────────────────────────────────────────────────────────
+// ── State builders ────────────────────────────────────────────────────────────
 
 /// Build an `AppState` backed by an in-memory SQLite database.
 ///
-/// Uses a pool capped at one connection so that all reads/writes share the
-/// same in-memory database instance.
-pub async fn build_test_state(
+/// Accepts both a `MockKeycloak` and a `MockMas` for full control.
+/// Uses `TEST_KEY` for cookie encryption so that `make_auth_cookie` produces
+/// cookies this state will accept.
+pub async fn build_test_state_full(
     keycloak: MockKeycloak,
+    mas: MockMas,
     bot_secret: &str,
     allowed_domains: Option<Vec<String>>,
 ) -> AppState {
@@ -187,7 +238,7 @@ pub async fn build_test_state(
     });
 
     let keycloak: Arc<dyn KeycloakApi> = Arc::new(keycloak);
-    let mas: Arc<dyn MasApi> = Arc::new(MockMas::default());
+    let mas: Arc<dyn MasApi> = Arc::new(mas);
     let users = Arc::new(UserService::new(
         Arc::clone(&keycloak),
         Arc::clone(&mas),
@@ -195,7 +246,7 @@ pub async fn build_test_state(
     ));
     let audit = Arc::new(AuditService::new(pool.clone()));
     let oidc = Arc::new(OidcClient::new_stub());
-    let cookie_key = Key::generate();
+    let cookie_key = Key::from(TEST_KEY);
 
     AppState {
         config,
@@ -209,17 +260,74 @@ pub async fn build_test_state(
     }
 }
 
-// ── Router builder ────────────────────────────────────────────────────────────
+/// Build an `AppState` with a default `MockMas`. Convenience wrapper around
+/// `build_test_state_full` for tests that only care about Keycloak behaviour
+/// (e.g. invite handler tests).
+pub async fn build_test_state(
+    keycloak: MockKeycloak,
+    bot_secret: &str,
+    allowed_domains: Option<Vec<String>>,
+) -> AppState {
+    build_test_state_full(keycloak, MockMas::default(), bot_secret, allowed_domains).await
+}
 
-/// Build a minimal router that only exposes the invite endpoint.
+// ── Auth helpers ──────────────────────────────────────────────────────────────
+
+/// Build an encrypted session cookie header value for use in test requests.
 ///
-/// Auth-protected routes are intentionally excluded — the invite endpoint
-/// uses bearer token auth, not the OIDC session cookie.
+/// Uses `TEST_KEY` — the same key baked into `build_test_state_full` — so
+/// the returned cookie will be accepted by any state built with that function.
+pub fn make_auth_cookie(csrf: &str) -> String {
+    use cookie::{Cookie as RawCookie, CookieJar};
+
+    let session = AdminSession {
+        subject: "test-subject".to_string(),
+        username: "test-admin".to_string(),
+        email: Some("admin@test.com".to_string()),
+        roles: vec!["matrix-admin".to_string()],
+        csrf_token: csrf.to_string(),
+    };
+    let json = serde_json::to_string(&session).unwrap();
+
+    let key = Key::from(TEST_KEY);
+    let mut jar = CookieJar::new();
+    jar.private_mut(&key).add(RawCookie::new("session", json));
+
+    jar.iter()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+// ── Router builders ───────────────────────────────────────────────────────────
+
+/// Minimal router exposing only the invite endpoint (bearer-token auth).
 pub fn invite_router(state: AppState) -> Router {
     Router::new()
         .route(
             "/api/v1/invites",
             post(crate::handlers::invite::create_invite),
+        )
+        .with_state(state)
+}
+
+/// Router exposing all session-authenticated mutation endpoints.
+///
+/// Used to test the revoke, force-logout, and delete handlers without
+/// standing up the full application.
+pub fn mutations_router(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/users/{id}/sessions/{session_id}/revoke",
+            post(crate::handlers::sessions::revoke),
+        )
+        .route(
+            "/users/{id}/keycloak/logout",
+            post(crate::handlers::devices::force_keycloak_logout),
+        )
+        .route(
+            "/users/{id}/delete",
+            post(crate::handlers::delete::delete_user),
         )
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Adds 16 new tests covering the three untested mutation handlers. Previously only the invite handler and service layer had tests.

**New test infrastructure (`test_helpers`):**
- `TEST_KEY` / `TEST_CSRF` constants for deterministic cookie encryption
- `build_test_state_full()` — accepts both `MockKeycloak` and `MockMas` for full control
- `make_auth_cookie()` — builds a real encrypted session cookie for test requests
- `mutations_router()` — minimal router for testing session-authenticated handlers
- `MockKeycloak` gains `fail_logout`, `fail_delete` fields
- `MockMas` gains `fail_finish_session`, `fail_delete_user` fields

**Tests added:**
- `handlers::delete` — success with MAS, success without MAS, 404, CSRF mismatch, unauthenticated, MAS failure aborts before KC, KC failure
- `handlers::sessions` — success, CSRF mismatch, unauthenticated, MAS failure, oauth2 session type
- `handlers::devices` — success, CSRF mismatch, unauthenticated, KC failure

**Total:** 40 → 56 tests

## Test plan
- [ ] `cargo test` passes clean
- [ ] `cargo clippy --all-targets -- -D warnings` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)