### PR TITLE
feat(audit): paginate audit log (50 per page)

### DIFF
--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -45,6 +45,36 @@ pub async fn recent(pool: &SqlitePool, limit: i64) -> Result<Vec<AuditLog>, AppE
     Ok(rows.into_iter().map(Into::into).collect())
 }
 
+pub async fn count(pool: &SqlitePool) -> Result<i64, AppError> {
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM audit_logs")
+        .fetch_one(pool)
+        .await?;
+    Ok(row.0)
+}
+
+pub async fn recent_page(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<AuditLog>, AppError> {
+    let rows: Vec<AuditLogRow> = sqlx::query_as::<_, AuditLogRow>(
+        r#"
+        SELECT id, timestamp, admin_subject, admin_username,
+               target_keycloak_user_id, target_matrix_user_id,
+               action, result, metadata_json
+        FROM audit_logs
+        ORDER BY timestamp DESC
+        LIMIT ? OFFSET ?
+        "#,
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(Into::into).collect())
+}
+
 pub async fn for_user(
     pool: &SqlitePool,
     keycloak_user_id: &str,

--- a/src/handlers/audit.rs
+++ b/src/handlers/audit.rs
@@ -1,7 +1,23 @@
 use askama::Template;
-use axum::{extract::State, response::Html};
+use axum::{
+    extract::{Query, State},
+    response::Html,
+};
+use serde::Deserialize;
 
 use crate::{auth::session::AuthenticatedAdmin, error::AppError, state::AppState};
+
+const PAGE_SIZE: i64 = 50;
+
+#[derive(Deserialize)]
+pub struct AuditQuery {
+    #[serde(default = "default_page")]
+    page: i64,
+}
+
+fn default_page() -> i64 {
+    1
+}
 
 #[derive(Template)]
 #[template(path = "audit.html")]
@@ -9,6 +25,8 @@ struct AuditTemplate {
     username: String,
     csrf_token: String,
     logs: Vec<AuditRow>,
+    page: i64,
+    total_pages: i64,
 }
 
 struct AuditRow {
@@ -23,8 +41,14 @@ struct AuditRow {
 pub async fn list(
     AuthenticatedAdmin(admin): AuthenticatedAdmin,
     State(state): State<AppState>,
+    Query(query): Query<AuditQuery>,
 ) -> Result<Html<String>, AppError> {
-    let logs = state.audit.recent(100).await?;
+    let total = state.audit.count().await?;
+    let total_pages = ((total + PAGE_SIZE - 1) / PAGE_SIZE).max(1);
+    let page = query.page.max(1).min(total_pages);
+    let offset = (page - 1) * PAGE_SIZE;
+
+    let logs = state.audit.recent_page(PAGE_SIZE, offset).await?;
 
     let rows = logs
         .into_iter()
@@ -42,6 +66,8 @@ pub async fn list(
         username: admin.username,
         csrf_token: admin.csrf_token,
         logs: rows,
+        page,
+        total_pages,
     }
     .render()
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Template error: {e}")))?;

--- a/src/services/audit_service.rs
+++ b/src/services/audit_service.rs
@@ -47,6 +47,14 @@ impl AuditService {
         db::audit::recent(&self.pool, limit).await
     }
 
+    pub async fn count(&self) -> Result<i64, AppError> {
+        db::audit::count(&self.pool).await
+    }
+
+    pub async fn recent_page(&self, limit: i64, offset: i64) -> Result<Vec<AuditLog>, AppError> {
+        db::audit::recent_page(&self.pool, limit, offset).await
+    }
+
     pub async fn for_user(
         &self,
         keycloak_user_id: &str,

--- a/static/app.css
+++ b/static/app.css
@@ -122,6 +122,10 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
 .result-success { color: #27ae60; font-weight: 500; }
 .result-failure { color: #c0392b; font-weight: 500; }
 
+/* ── Pagination ──────────────────────────────────────────────────────────── */
+.pagination { display: flex; align-items: center; gap: 1rem; margin-top: 1rem; }
+.btn-disabled { background: #e0e0e0; color: #999; cursor: default; pointer-events: none; }
+
 /* ── Login ───────────────────────────────────────────────────────────────── */
 .login-page { display: flex; align-items: center; justify-content: center; min-height: 100vh; }
 .login-box { background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 2.5rem; text-align: center; max-width: 360px; width: 100%; }

--- a/templates/audit.html
+++ b/templates/audit.html
@@ -13,7 +13,7 @@
 {% block content %}
 <div class="page-header">
   <h1>Audit Log</h1>
-  <p class="muted">Showing last 100 admin actions.</p>
+  <p class="muted">Page {{ page }} of {{ total_pages }}</p>
 </div>
 
 <div class="card">
@@ -52,4 +52,22 @@
     </table>
   {% endif %}
 </div>
+
+{% if total_pages > 1 %}
+<div class="pagination">
+  {% if page > 1 %}
+    <a href="/audit?page={{ page - 1 }}" class="btn">← Previous</a>
+  {% else %}
+    <span class="btn btn-disabled">← Previous</span>
+  {% endif %}
+
+  <span class="muted">Page {{ page }} of {{ total_pages }}</span>
+
+  {% if page < total_pages %}
+    <a href="/audit?page={{ page + 1 }}" class="btn">Next →</a>
+  {% else %}
+    <span class="btn btn-disabled">Next →</span>
+  {% endif %}
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Adds `?page=N` query param to `GET /audit`
- Page size: 50 entries; defaults to page 1
- Adds `count()` and `recent_page(limit, offset)` to `db/audit` and `AuditService`
- Template shows "Page N of M" subtitle and prev/next navigation buttons
- Disabled state for prev on page 1 and next on last page

## Test plan

- [ ] `/audit` loads with no query param → shows page 1
- [ ] `/audit?page=2` shows second page of results
- [ ] Out-of-range page (e.g. `?page=999`) clamps to last page
- [ ] Pagination controls hidden when there's only one page

🤖 Generated with [Claude Code](https://claude.com/claude-code)