### PR TITLE
feat(audit): add action and result filters

### DIFF
--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -75,6 +75,124 @@ pub async fn recent_page(
     Ok(rows.into_iter().map(Into::into).collect())
 }
 
+pub async fn count_filtered(
+    pool: &SqlitePool,
+    action: Option<&str>,
+    result: Option<&str>,
+) -> Result<i64, AppError> {
+    let row: (i64,) = match (action, result) {
+        (Some(a), Some(r)) => {
+            sqlx::query_as("SELECT COUNT(*) FROM audit_logs WHERE action = ? AND result = ?")
+                .bind(a)
+                .bind(r)
+                .fetch_one(pool)
+                .await?
+        }
+        (Some(a), None) => {
+            sqlx::query_as("SELECT COUNT(*) FROM audit_logs WHERE action = ?")
+                .bind(a)
+                .fetch_one(pool)
+                .await?
+        }
+        (None, Some(r)) => {
+            sqlx::query_as("SELECT COUNT(*) FROM audit_logs WHERE result = ?")
+                .bind(r)
+                .fetch_one(pool)
+                .await?
+        }
+        (None, None) => {
+            sqlx::query_as("SELECT COUNT(*) FROM audit_logs")
+                .fetch_one(pool)
+                .await?
+        }
+    };
+    Ok(row.0)
+}
+
+pub async fn recent_page_filtered(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+    action: Option<&str>,
+    result: Option<&str>,
+) -> Result<Vec<AuditLog>, AppError> {
+    let rows: Vec<AuditLogRow> = match (action, result) {
+        (Some(a), Some(r)) => {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT id, timestamp, admin_subject, admin_username,
+                       target_keycloak_user_id, target_matrix_user_id,
+                       action, result, metadata_json
+                FROM audit_logs
+                WHERE action = ? AND result = ?
+                ORDER BY timestamp DESC
+                LIMIT ? OFFSET ?
+                "#,
+            )
+            .bind(a)
+            .bind(r)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+        (Some(a), None) => {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT id, timestamp, admin_subject, admin_username,
+                       target_keycloak_user_id, target_matrix_user_id,
+                       action, result, metadata_json
+                FROM audit_logs
+                WHERE action = ?
+                ORDER BY timestamp DESC
+                LIMIT ? OFFSET ?
+                "#,
+            )
+            .bind(a)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+        (None, Some(r)) => {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT id, timestamp, admin_subject, admin_username,
+                       target_keycloak_user_id, target_matrix_user_id,
+                       action, result, metadata_json
+                FROM audit_logs
+                WHERE result = ?
+                ORDER BY timestamp DESC
+                LIMIT ? OFFSET ?
+                "#,
+            )
+            .bind(r)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+        (None, None) => {
+            sqlx::query_as::<_, AuditLogRow>(
+                r#"
+                SELECT id, timestamp, admin_subject, admin_username,
+                       target_keycloak_user_id, target_matrix_user_id,
+                       action, result, metadata_json
+                FROM audit_logs
+                ORDER BY timestamp DESC
+                LIMIT ? OFFSET ?
+                "#,
+            )
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+
+    Ok(rows.into_iter().map(Into::into).collect())
+}
+
 pub async fn for_user(
     pool: &SqlitePool,
     keycloak_user_id: &str,
@@ -310,5 +428,165 @@ mod tests {
         let pool = setup_db().await;
         assert!(recent(&pool, 10).await.unwrap().is_empty());
         assert!(for_user(&pool, "kc-001", 10).await.unwrap().is_empty());
+    }
+
+    fn make_log_with_result(id: &str, timestamp: &str, action: &str, result: &str) -> AuditLog {
+        AuditLog {
+            id: id.to_string(),
+            timestamp: timestamp.to_string(),
+            admin_subject: "admin-subject".to_string(),
+            admin_username: "admin".to_string(),
+            target_keycloak_user_id: None,
+            target_matrix_user_id: None,
+            action: action.to_string(),
+            result: result.to_string(),
+            metadata_json: "{}".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn count_filtered_by_action() {
+        let pool = setup_db().await;
+        insert(
+            &pool,
+            &make_log_with_result("1", "2024-01-01T00:00:00Z", "invite_user", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("2", "2024-01-01T00:00:01Z", "revoke_session", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("3", "2024-01-01T00:00:02Z", "invite_user", "failure"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_filtered(&pool, Some("invite_user"), None)
+                .await
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            count_filtered(&pool, Some("revoke_session"), None)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(count_filtered(&pool, None, None).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn count_filtered_by_result() {
+        let pool = setup_db().await;
+        insert(
+            &pool,
+            &make_log_with_result("1", "2024-01-01T00:00:00Z", "invite_user", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("2", "2024-01-01T00:00:01Z", "invite_user", "failure"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_filtered(&pool, None, Some("success")).await.unwrap(),
+            1
+        );
+        assert_eq!(
+            count_filtered(&pool, None, Some("failure")).await.unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn count_filtered_by_action_and_result() {
+        let pool = setup_db().await;
+        insert(
+            &pool,
+            &make_log_with_result("1", "2024-01-01T00:00:00Z", "invite_user", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("2", "2024-01-01T00:00:01Z", "invite_user", "failure"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("3", "2024-01-01T00:00:02Z", "revoke_session", "success"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_filtered(&pool, Some("invite_user"), Some("success"))
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            count_filtered(&pool, Some("invite_user"), Some("failure"))
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            count_filtered(&pool, Some("revoke_session"), Some("failure"))
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn recent_page_filtered_returns_correct_rows() {
+        let pool = setup_db().await;
+        insert(
+            &pool,
+            &make_log_with_result("1", "2024-01-01T00:00:00Z", "invite_user", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("2", "2024-01-01T00:00:01Z", "revoke_session", "success"),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &make_log_with_result("3", "2024-01-01T00:00:02Z", "invite_user", "failure"),
+        )
+        .await
+        .unwrap();
+
+        let rows = recent_page_filtered(&pool, 10, 0, Some("invite_user"), None)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.action == "invite_user"));
+
+        let rows = recent_page_filtered(&pool, 10, 0, Some("invite_user"), Some("success"))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "1");
+
+        let rows = recent_page_filtered(&pool, 10, 0, None, Some("failure"))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "3");
     }
 }

--- a/src/handlers/audit.rs
+++ b/src/handlers/audit.rs
@@ -13,6 +13,8 @@ const PAGE_SIZE: i64 = 50;
 pub struct AuditQuery {
     #[serde(default = "default_page")]
     page: i64,
+    action: Option<String>,
+    result: Option<String>,
 }
 
 fn default_page() -> i64 {
@@ -27,6 +29,8 @@ struct AuditTemplate {
     logs: Vec<AuditRow>,
     page: i64,
     total_pages: i64,
+    action_filter: String,
+    result_filter: String,
 }
 
 struct AuditRow {
@@ -43,12 +47,29 @@ pub async fn list(
     State(state): State<AppState>,
     Query(query): Query<AuditQuery>,
 ) -> Result<Html<String>, AppError> {
-    let total = state.audit.count().await?;
+    let action_filter = query.action.unwrap_or_default();
+    let result_filter = query.result.unwrap_or_default();
+
+    let action_opt = if action_filter.is_empty() {
+        None
+    } else {
+        Some(action_filter.as_str())
+    };
+    let result_opt = if result_filter.is_empty() {
+        None
+    } else {
+        Some(result_filter.as_str())
+    };
+
+    let total = state.audit.count_filtered(action_opt, result_opt).await?;
     let total_pages = ((total + PAGE_SIZE - 1) / PAGE_SIZE).max(1);
     let page = query.page.max(1).min(total_pages);
     let offset = (page - 1) * PAGE_SIZE;
 
-    let logs = state.audit.recent_page(PAGE_SIZE, offset).await?;
+    let logs = state
+        .audit
+        .recent_page_filtered(PAGE_SIZE, offset, action_opt, result_opt)
+        .await?;
 
     let rows = logs
         .into_iter()
@@ -68,6 +89,8 @@ pub async fn list(
         logs: rows,
         page,
         total_pages,
+        action_filter,
+        result_filter,
     }
     .render()
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Template error: {e}")))?;

--- a/src/services/audit_service.rs
+++ b/src/services/audit_service.rs
@@ -55,6 +55,24 @@ impl AuditService {
         db::audit::recent_page(&self.pool, limit, offset).await
     }
 
+    pub async fn count_filtered(
+        &self,
+        action: Option<&str>,
+        result: Option<&str>,
+    ) -> Result<i64, AppError> {
+        db::audit::count_filtered(&self.pool, action, result).await
+    }
+
+    pub async fn recent_page_filtered(
+        &self,
+        limit: i64,
+        offset: i64,
+        action: Option<&str>,
+        result: Option<&str>,
+    ) -> Result<Vec<AuditLog>, AppError> {
+        db::audit::recent_page_filtered(&self.pool, limit, offset, action, result).await
+    }
+
     pub async fn for_user(
         &self,
         keycloak_user_id: &str,

--- a/static/app.css
+++ b/static/app.css
@@ -75,6 +75,10 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
   font-size: 14px;
 }
 
+.filter-row { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+.filter-row input[type=text] { flex: 1; padding: 0.4rem 0.75rem; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
+.filter-row select { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
+
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
 .btn {
   display: inline-block;

--- a/templates/audit.html
+++ b/templates/audit.html
@@ -16,6 +16,17 @@
   <p class="muted">Page {{ page }} of {{ total_pages }}</p>
 </div>
 
+<form method="get" action="/audit" class="filter-row">
+  <input type="text" name="action" placeholder="Filter by action…" value="{{ action_filter }}">
+  <select name="result">
+    <option value="">All results</option>
+    <option value="success" {% if result_filter == "success" %}selected{% endif %}>Success</option>
+    <option value="failure" {% if result_filter == "failure" %}selected{% endif %}>Failure</option>
+  </select>
+  <button type="submit" class="btn btn-primary btn-sm">Filter</button>
+  <a href="/audit" class="btn btn-sm">Clear</a>
+</form>
+
 <div class="card">
   {% if logs.is_empty() %}
     <p class="muted">No audit entries yet.</p>
@@ -56,7 +67,7 @@
 {% if total_pages > 1 %}
 <div class="pagination">
   {% if page > 1 %}
-    <a href="/audit?page={{ page - 1 }}" class="btn">← Previous</a>
+    <a href="/audit?page={{ page - 1 }}{% if !action_filter.is_empty() %}&action={{ action_filter }}{% endif %}{% if !result_filter.is_empty() %}&result={{ result_filter }}{% endif %}" class="btn">← Previous</a>
   {% else %}
     <span class="btn btn-disabled">← Previous</span>
   {% endif %}
@@ -64,7 +75,7 @@
   <span class="muted">Page {{ page }} of {{ total_pages }}</span>
 
   {% if page < total_pages %}
-    <a href="/audit?page={{ page + 1 }}" class="btn">Next →</a>
+    <a href="/audit?page={{ page + 1 }}{% if !action_filter.is_empty() %}&action={{ action_filter }}{% endif %}{% if !result_filter.is_empty() %}&result={{ result_filter }}{% endif %}" class="btn">Next →</a>
   {% else %}
     <span class="btn btn-disabled">Next →</span>
   {% endif %}


### PR DESCRIPTION
## Summary

- Adds optional `?action=` and `?result=` query params to `GET /audit`
- Filter form above the table (text input for action, dropdown for success/failure/all)
- Pagination links preserve active filters
- New `count_filtered` / `recent_page_filtered` functions in db and service layers
- 4 new unit tests covering all filter combinations (action only, result only, both, neither)

## Test results
- 74 unit tests passing (4 new)
- 7 e2e tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)