### PR TITLE
feat(users): paginate user search results (25 per page)

### DIFF
--- a/src/clients/keycloak.rs
+++ b/src/clients/keycloak.rs
@@ -11,7 +11,14 @@ use crate::{
 
 #[async_trait]
 pub trait KeycloakApi: Send + Sync {
-    async fn search_users(&self, query: &str) -> Result<Vec<KeycloakUser>, AppError>;
+    async fn search_users(
+        &self,
+        query: &str,
+        max: u32,
+        first: u32,
+    ) -> Result<Vec<KeycloakUser>, AppError>;
+    /// Return the total count of users matching `query` (calls `/users/count?search=...`).
+    async fn count_users(&self, query: &str) -> Result<u32, AppError>;
     async fn get_user(&self, user_id: &str) -> Result<KeycloakUser, AppError>;
     async fn get_user_by_email(&self, email: &str) -> Result<Option<KeycloakUser>, AppError>;
     async fn get_user_groups(&self, user_id: &str) -> Result<Vec<KeycloakGroup>, AppError>;
@@ -111,7 +118,12 @@ impl KeycloakClient {
 
 #[async_trait]
 impl KeycloakApi for KeycloakClient {
-    async fn search_users(&self, query: &str) -> Result<Vec<KeycloakUser>, AppError> {
+    async fn search_users(
+        &self,
+        query: &str,
+        max: u32,
+        first: u32,
+    ) -> Result<Vec<KeycloakUser>, AppError> {
         let token = self.admin_token().await?;
         let url = self.admin_url("/users");
 
@@ -119,7 +131,11 @@ impl KeycloakApi for KeycloakClient {
             .http
             .get(&url)
             .bearer_auth(&token)
-            .query(&[("search", query), ("max", "50")])
+            .query(&[
+                ("search", query),
+                ("max", &max.to_string()),
+                ("first", &first.to_string()),
+            ])
             .send()
             .await
             .map_err(|e| upstream_error("keycloak", e))?
@@ -130,6 +146,27 @@ impl KeycloakApi for KeycloakClient {
             .map_err(|e| upstream_error("keycloak", e))?;
 
         Ok(users)
+    }
+
+    async fn count_users(&self, query: &str) -> Result<u32, AppError> {
+        let token = self.admin_token().await?;
+        let url = self.admin_url("/users/count");
+
+        let count: u32 = self
+            .http
+            .get(&url)
+            .bearer_auth(&token)
+            .query(&[("search", query)])
+            .send()
+            .await
+            .map_err(|e| upstream_error("keycloak", e))?
+            .error_for_status()
+            .map_err(|e| upstream_error("keycloak", e))?
+            .json()
+            .await
+            .map_err(|e| upstream_error("keycloak", e))?;
+
+        Ok(count)
     }
 
     async fn get_user(&self, user_id: &str) -> Result<KeycloakUser, AppError> {

--- a/src/handlers/users.rs
+++ b/src/handlers/users.rs
@@ -14,9 +14,12 @@ use crate::{
 
 // ── Search ────────────────────────────────────────────────────────────────────
 
+const PAGE_SIZE: u32 = 25;
+
 #[derive(Deserialize)]
 pub struct SearchParams {
     pub q: Option<String>,
+    pub page: Option<u32>,
 }
 
 #[derive(Template)]
@@ -26,6 +29,8 @@ struct SearchTemplate {
     csrf_token: String,
     query: String,
     results: Vec<UnifiedUserSummary>,
+    page: u32,
+    total_pages: u32,
 }
 
 pub async fn search(
@@ -34,11 +39,16 @@ pub async fn search(
     Query(params): Query<SearchParams>,
 ) -> Result<Html<String>, AppError> {
     let query = params.q.unwrap_or_default();
+    let page = params.page.unwrap_or(1).max(1);
 
-    let results = if query.is_empty() {
-        vec![]
+    let (results, total_pages) = if query.is_empty() {
+        (vec![], 1)
     } else {
-        state.users.search(&query).await?
+        let first = (page - 1) * PAGE_SIZE;
+        let total = state.keycloak.count_users(&query).await?;
+        let total_pages = total.div_ceil(PAGE_SIZE).max(1);
+        let results = state.users.search(&query, PAGE_SIZE, first).await?;
+        (results, total_pages)
     };
 
     let html = SearchTemplate {
@@ -46,6 +56,8 @@ pub async fn search(
         csrf_token: admin.csrf_token,
         query,
         results,
+        page,
+        total_pages,
     }
     .render()
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Template error: {e}")))?;

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -26,10 +26,16 @@ impl UserService {
         }
     }
 
-    /// Search Keycloak for users matching `query`. Returns lightweight summaries
-    /// with derived Matrix IDs but does not fan out to MAS per result.
-    pub async fn search(&self, query: &str) -> Result<Vec<UnifiedUserSummary>, AppError> {
-        let users = self.keycloak.search_users(query).await?;
+    /// Search Keycloak for users matching `query` with server-side pagination.
+    /// Returns lightweight summaries with derived Matrix IDs but does not fan
+    /// out to MAS per result.
+    pub async fn search(
+        &self,
+        query: &str,
+        max: u32,
+        first: u32,
+    ) -> Result<Vec<UnifiedUserSummary>, AppError> {
+        let users = self.keycloak.search_users(query, max, first).await?;
 
         let summaries = users
             .into_iter()
@@ -157,8 +163,16 @@ mod tests {
 
     #[async_trait]
     impl KeycloakApi for MockKeycloak {
-        async fn search_users(&self, _query: &str) -> Result<Vec<KeycloakUser>, AppError> {
+        async fn search_users(
+            &self,
+            _query: &str,
+            _max: u32,
+            _first: u32,
+        ) -> Result<Vec<KeycloakUser>, AppError> {
             Ok(self.users.clone())
+        }
+        async fn count_users(&self, _query: &str) -> Result<u32, AppError> {
+            Ok(self.users.len() as u32)
         }
         async fn get_user(&self, _user_id: &str) -> Result<KeycloakUser, AppError> {
             self.users
@@ -252,7 +266,7 @@ mod tests {
             },
         );
 
-        let results = svc.search("alice").await.unwrap();
+        let results = svc.search("alice", 25, 0).await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].username, "alice");
         assert_eq!(
@@ -276,7 +290,7 @@ mod tests {
             },
         );
 
-        let results = svc.search("nobody").await.unwrap();
+        let results = svc.search("nobody", 25, 0).await.unwrap();
         assert!(results.is_empty());
     }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -72,8 +72,17 @@ impl Default for MockKeycloak {
 
 #[async_trait]
 impl KeycloakApi for MockKeycloak {
-    async fn search_users(&self, _query: &str) -> Result<Vec<KeycloakUser>, AppError> {
+    async fn search_users(
+        &self,
+        _query: &str,
+        _max: u32,
+        _first: u32,
+    ) -> Result<Vec<KeycloakUser>, AppError> {
         Ok(self.users.clone())
+    }
+
+    async fn count_users(&self, _query: &str) -> Result<u32, AppError> {
+        Ok(self.users.len() as u32)
     }
 
     async fn get_user(&self, _user_id: &str) -> Result<KeycloakUser, AppError> {

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -55,5 +55,23 @@
     </table>
   {% endif %}
 </div>
+
+{% if total_pages > 1 %}
+<div class="pagination">
+  {% if page > 1 %}
+    <a href="/users?q={{ query }}&page={{ page - 1 }}" class="btn">← Previous</a>
+  {% else %}
+    <span class="btn btn-disabled">← Previous</span>
+  {% endif %}
+
+  <span class="muted">Page {{ page }} of {{ total_pages }}</span>
+
+  {% if page < total_pages %}
+    <a href="/users?q={{ query }}&page={{ page + 1 }}" class="btn">Next →</a>
+  {% else %}
+    <span class="btn btn-disabled">Next →</span>
+  {% endif %}
+</div>
+{% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Wires Keycloak server-side \`first\`/\`max\` params and \`/users/count\` through the full stack so search fetches exactly one 25-result page instead of an unbounded slice
- Adds \`count_users(query)\` to \`KeycloakApi\` trait and \`KeycloakClient\`
- Updates \`search_users\` signature to accept \`max: u32, first: u32\` throughout trait, client, \`UserService\`, mocks, and all call sites
- Handler accepts \`?page=N\` (defaults to 1), computes offset, calls \`count_users\` + \`search_users\`, passes \`page\`/\`total_pages\` to template
- Template adds prev/next pagination controls preserving \`?q=\` param (same pattern as \`audit.html\`)

## Test results
- 70 unit tests passing
- 7 e2e tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)