### PR TITLE
fix: align docs, search routes, and coverage command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage report
-        run: >
-          cargo llvm-cov --lib --lcov --output-path lcov.info
-          --ignore-filename-regex "(clients/|handlers/auth\.rs|auth/oidc\.rs|config\.rs|db/mod\.rs|lib\.rs)"
+        run: cargo llvm-cov --workspace --all-targets --lcov --output-path lcov.info
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It provides a unified admin view over:
 Supported admin actions:
 - Revoke MAS sessions (compat and OAuth2)
 - Force Keycloak logout
-- Delete users (from Keycloak and MAS atomically)
+- Delete users from both Keycloak and MAS (best-effort sequence: MAS first, then Keycloak)
 - Invite users via a bot-driven API (maubot plugin included)
 
 All mutations are audit-logged to SQLite.
@@ -212,6 +212,13 @@ cargo fmt
 # Inside Flox environment (required on macOS)
 flox activate -- cargo run
 ```
+
+## For Coding Agents
+
+- Start with [CLAUDE.md](CLAUDE.md) for architecture and guardrails.
+- Use `cargo test` for fast local verification.
+- Run e2e tests (Docker required): `cargo test --test e2e -- --include-ignored`
+- If modifying search routes/templates, keep `/users/search` consistent across router, templates, and tests.
 
 ## Security Notes
 

--- a/src/handlers/users.rs
+++ b/src/handlers/users.rs
@@ -155,9 +155,9 @@ mod tests {
         auth_cookie: Option<&str>,
     ) -> axum::response::Response {
         let uri = if query.is_empty() {
-            "/users".to_string()
+            "/users/search".to_string()
         } else {
-            format!("/users?q={query}")
+            format!("/users/search?q={query}")
         };
         let mut builder = Request::builder().method(Method::GET).uri(uri);
         if let Some(cookie) = auth_cookie {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -349,7 +349,7 @@ pub fn invite_router(state: AppState) -> Router {
 pub fn reads_router(state: AppState) -> Router {
     use axum::routing::get;
     Router::new()
-        .route("/users", get(crate::handlers::users::search))
+        .route("/users/search", get(crate::handlers::users::search))
         .route("/users/{id}", get(crate::handlers::users::detail))
         .with_state(state)
 }

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -59,7 +59,7 @@
 {% if total_pages > 1 %}
 <div class="pagination">
   {% if page > 1 %}
-    <a href="/users?q={{ query }}&page={{ page - 1 }}" class="btn">← Previous</a>
+    <a href="/users/search?q={{ query }}&page={{ page - 1 }}" class="btn">← Previous</a>
   {% else %}
     <span class="btn btn-disabled">← Previous</span>
   {% endif %}
@@ -67,7 +67,7 @@
   <span class="muted">Page {{ page }} of {{ total_pages }}</span>
 
   {% if page < total_pages %}
-    <a href="/users?q={{ query }}&page={{ page + 1 }}" class="btn">Next →</a>
+    <a href="/users/search?q={{ query }}&page={{ page + 1 }}" class="btn">Next →</a>
   {% else %}
     <span class="btn btn-disabled">Next →</span>
   {% endif %}


### PR DESCRIPTION
## Summary
- fix user search pagination links to use `/users/search` so UI links match production routes
- align user-search test helper routing and handler tests with `/users/search`
- update README delete action wording from atomic to best-effort sequence (MAS then Keycloak)
- add a short "For Coding Agents" section to README with key workflows
- update CI coverage command to report workspace/all-target coverage without filtering out major modules

## Validation
- cargo test (116 passed, 0 failed)
