### PR TITLE
security: harden invite audit actor, logout CSRF, and static serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1427,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -2764,6 +2780,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,12 +2816,20 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2884,6 +2921,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["cookie-private"] }
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["trace", "timeout"] }
+tower-http = { version = "0.6", features = ["trace", "timeout", "fs"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 
 use crate::{
     auth::{
-        csrf::generate_token,
+        csrf::{generate_token, validate},
         oidc::{OidcFlowState, OIDC_FLOW_COOKIE},
-        session::{build_session_cookie, clear_session, AdminSession},
+        session::{build_session_cookie, clear_session, AdminSession, AuthenticatedAdmin},
     },
     error::AppError,
     state::AppState,
@@ -38,6 +38,11 @@ pub async fn login(
 pub struct CallbackParams {
     pub code: String,
     pub state: String,
+}
+
+#[derive(Deserialize)]
+pub struct LogoutForm {
+    pub _csrf: String,
 }
 
 pub async fn callback(
@@ -76,7 +81,74 @@ pub async fn callback(
     Ok((jar, Redirect::to("/")))
 }
 
-pub async fn logout(jar: PrivateCookieJar) -> impl IntoResponse {
+pub async fn logout(
+    AuthenticatedAdmin(admin): AuthenticatedAdmin,
+    jar: PrivateCookieJar,
+    axum::extract::Form(form): axum::extract::Form<LogoutForm>,
+) -> Result<impl IntoResponse, AppError> {
+    validate(&admin.csrf_token, &form._csrf)?;
     let jar = clear_session(jar);
-    (jar, Redirect::to("/auth/login"))
+    Ok((jar, Redirect::to("/auth/login")))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use crate::test_helpers::{build_test_state, make_auth_cookie, MockKeycloak, TEST_CSRF};
+
+    use super::logout;
+
+    async fn post_logout(
+        state: crate::state::AppState,
+        csrf: &str,
+        auth_cookie: Option<&str>,
+    ) -> axum::response::Response {
+        let body = format!("_csrf={csrf}");
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/auth/logout")
+            .header("content-type", "application/x-www-form-urlencoded");
+        if let Some(cookie) = auth_cookie {
+            builder = builder.header("cookie", cookie);
+        }
+
+        Router::new()
+            .route("/auth/logout", post(logout))
+            .with_state(state)
+            .oneshot(builder.body(Body::from(body)).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn logout_with_valid_csrf_redirects_to_login() {
+        let state = build_test_state(MockKeycloak::default(), "secret", None).await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_logout(state, TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn logout_with_invalid_csrf_returns_400() {
+        let state = build_test_state(MockKeycloak::default(), "secret", None).await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_logout(state, "wrong-csrf", Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn logout_unauthenticated_redirects_to_login() {
+        let state = build_test_state(MockKeycloak::default(), "secret", None).await;
+        let resp = post_logout(state, TEST_CSRF, None).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
 }

--- a/src/handlers/invite.rs
+++ b/src/handlers/invite.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Deserialize)]
 pub struct InviteRequest {
     pub email: String,
-    /// Matrix display name or username of the admin who issued the invite command.
+    /// Bot-provided attribution string (stored as metadata only).
     pub invited_by: String,
 }
 
@@ -67,7 +67,7 @@ pub async fn admin_invite(
         return Redirect::to(&format!("/?error={}", pct_encode(&e.to_string()))).into_response();
     }
 
-    match perform_invite(&state, &form.email, &admin.username).await {
+    match perform_invite(&state, &form.email, &admin.subject, &admin.username, None).await {
         Ok(email) => Redirect::to(&format!(
             "/?notice={}",
             pct_encode(&format!("Invite sent to {email}"))
@@ -125,7 +125,15 @@ async fn handle_invite(
         return Err(AppError::Auth("Invalid bot API secret".to_string()));
     }
 
-    perform_invite(state, &body.email, &body.invited_by).await
+    // Do not trust caller-provided attribution for audit actor identity.
+    perform_invite(
+        state,
+        &body.email,
+        "bot-api",
+        "bot-api",
+        Some(&body.invited_by),
+    )
+    .await
 }
 
 /// Core invite logic shared between the bot API and the admin UI handler.
@@ -134,7 +142,9 @@ async fn handle_invite(
 pub(crate) async fn perform_invite(
     state: &AppState,
     raw_email: &str,
-    invited_by: &str,
+    actor_subject: &str,
+    actor_username: &str,
+    requested_by: Option<&str>,
 ) -> Result<String, AppError> {
     // ── Validate email ────────────────────────────────────────────────────────
     let email = raw_email.trim().to_lowercase();
@@ -195,8 +205,8 @@ pub(crate) async fn perform_invite(
             state
                 .audit
                 .log(
-                    invited_by,
-                    invited_by,
+                    actor_subject,
+                    actor_username,
                     Some(&user_id),
                     Some(&matrix_user_id),
                     "reactivate_mas_user",
@@ -225,15 +235,15 @@ pub(crate) async fn perform_invite(
     state
         .audit
         .log(
-            invited_by,
-            invited_by,
+            actor_subject,
+            actor_username,
             Some(&user_id),
             Some(&matrix_user_id),
             "invite_user",
             audit_result,
             json!({
                 "email": email,
-                "invited_by": invited_by,
+                "requested_by": requested_by,
                 "keycloak_user_id": user_id,
             }),
         )
@@ -735,6 +745,56 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
         let json = json_body(resp).await;
         assert_eq!(json["ok"], false);
+    }
+
+    #[tokio::test]
+    async fn bot_invite_uses_trusted_audit_actor_not_payload_invited_by() {
+        let state = build_test_state(MockKeycloak::default(), SECRET, None).await;
+        let audit = std::sync::Arc::clone(&state.audit);
+        let resp = post_invite(
+            state,
+            Some(&format!("Bearer {SECRET}")),
+            Body::from(r#"{"email":"user@test.com","invited_by":"spoofed-admin"}"#),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let logs = audit.for_user("new-kc-id", 10).await.unwrap();
+        assert!(
+            logs.iter().any(|l| l.action == "invite_user"),
+            "expected invite_user audit log"
+        );
+        let invite_log = logs
+            .into_iter()
+            .find(|l| l.action == "invite_user")
+            .unwrap();
+        assert_eq!(invite_log.admin_subject, "bot-api");
+        assert_eq!(invite_log.admin_username, "bot-api");
+        assert!(invite_log.metadata_json.contains("spoofed-admin"));
+    }
+
+    #[tokio::test]
+    async fn admin_invite_uses_authenticated_admin_as_audit_actor() {
+        let state = build_test_state(MockKeycloak::default(), SECRET, None).await;
+        let audit = std::sync::Arc::clone(&state.audit);
+        let resp = post_admin_invite(
+            state,
+            Some(make_auth_cookie(TEST_CSRF)),
+            &format!("email=new%40test.com&_csrf={TEST_CSRF}"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+
+        let logs = audit.for_user("new-kc-id", 10).await.unwrap();
+        assert!(
+            logs.iter().any(|l| l.action == "invite_user"),
+            "expected invite_user audit log"
+        );
+        let invite_log = logs
+            .into_iter()
+            .find(|l| l.action == "invite_user")
+            .unwrap();
+        assert_eq!(invite_log.admin_username, "test-admin");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::Key;
 use sha2::{Digest, Sha512};
-use tower_http::timeout::TimeoutLayer;
+use tower_http::{services::ServeDir, timeout::TimeoutLayer};
 
 use clients::{KeycloakClient, MasClient};
 use config::Config;
@@ -70,6 +70,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/auth/login", get(handlers::auth::login))
         .route("/auth/callback", get(handlers::auth::callback))
         .route("/auth/logout", post(handlers::auth::logout))
+        // Static assets
+        .nest_service("/static", ServeDir::new("static"))
         // Dashboard
         .route("/", get(handlers::dashboard::dashboard))
         // User search & detail


### PR DESCRIPTION
## Summary
- trust audit actor identity for bot invites (`bot-api`) instead of caller-supplied `invited_by`
- keep caller `invited_by` as metadata only (`requested_by`) for attribution/debugging
- enforce CSRF validation on `POST /auth/logout`
- add logout handler tests for valid CSRF, invalid CSRF, and unauthenticated behavior
- serve static assets directly from app router via `/static` using `tower-http` `ServeDir`

## Validation
- cargo test (121 passed, 0 failed)
- cargo clippy --all-targets -- -D warnings
