### PR TITLE
fix(ci): poll HTTP endpoints instead of Docker health status

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,41 +39,32 @@ jobs:
       - name: Start e2e Docker stack
         run: docker compose -f e2e/docker-compose.yml up -d
 
-      - name: Wait for all services to become healthy
+      - name: Wait for all services to become ready
         run: |
-          services=(keycloak mas mailpit)
-          deadline=$((SECONDS + 300))
-          all_healthy=false
-
-          while [ $SECONDS -lt $deadline ]; do
-            all_healthy=true
-            for svc in "${services[@]}"; do
-              id=$(docker compose -f e2e/docker-compose.yml ps -q "$svc" 2>/dev/null)
-              if [ -z "$id" ]; then
-                all_healthy=false
-                break
+          # Poll HTTP endpoints from the runner rather than relying on Docker
+          # healthchecks — MAS is distroless and Mailpit is scratch-based, so
+          # neither image has curl/shell for in-container health probes.
+          wait_for_http() {
+            local name=$1 url=$2
+            local deadline=$((SECONDS + 300))
+            echo "Waiting for $name ($url)..."
+            while [ $SECONDS -lt $deadline ]; do
+              if curl -sf --max-time 3 -o /dev/null "$url" 2>/dev/null; then
+                echo "$name ready (${SECONDS}s)"
+                return 0
               fi
-              status=$(docker inspect --format='{{.State.Health.Status}}' "$id" 2>/dev/null)
-              if [ "$status" != "healthy" ]; then
-                all_healthy=false
-                break
-              fi
+              sleep 5
             done
+            echo "ERROR: $name did not become ready within 300s"
+            docker compose -f e2e/docker-compose.yml logs "$name" 2>/dev/null || true
+            return 1
+          }
 
-            if $all_healthy; then
-              echo "All services healthy after ${SECONDS}s."
-              break
-            fi
-
-            echo "Waiting for services... (${SECONDS}s elapsed)"
-            sleep 5
-          done
-
-          if ! $all_healthy; then
-            echo "Timed out waiting for services to become healthy."
-            docker compose -f e2e/docker-compose.yml ps
-            exit 1
-          fi
+          # Keycloak first — MAS depends on it being up
+          wait_for_http keycloak  "http://localhost:8081/realms/test"
+          wait_for_http mas       "http://localhost:8082/.well-known/openid-configuration"
+          wait_for_http mailpit   "http://localhost:8025/api/v1/messages"
+          echo "All services ready."
 
       - name: Run e2e tests
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,41 +110,28 @@ jobs:
       - name: Start e2e Docker stack
         run: docker compose -f e2e/docker-compose.yml up -d
 
-      - name: Wait for all services to become healthy
+      - name: Wait for all services to become ready
         run: |
-          services=(keycloak mas mailpit)
-          deadline=$((SECONDS + 300))
-          all_healthy=false
-
-          while [ $SECONDS -lt $deadline ]; do
-            all_healthy=true
-            for svc in "${services[@]}"; do
-              id=$(docker compose -f e2e/docker-compose.yml ps -q "$svc" 2>/dev/null)
-              if [ -z "$id" ]; then
-                all_healthy=false
-                break
+          wait_for_http() {
+            local name=$1 url=$2
+            local deadline=$((SECONDS + 300))
+            echo "Waiting for $name ($url)..."
+            while [ $SECONDS -lt $deadline ]; do
+              if curl -sf --max-time 3 -o /dev/null "$url" 2>/dev/null; then
+                echo "$name ready (${SECONDS}s)"
+                return 0
               fi
-              status=$(docker inspect --format='{{.State.Health.Status}}' "$id" 2>/dev/null)
-              if [ "$status" != "healthy" ]; then
-                all_healthy=false
-                break
-              fi
+              sleep 5
             done
+            echo "ERROR: $name did not become ready within 300s"
+            docker compose -f e2e/docker-compose.yml logs "$name" 2>/dev/null || true
+            return 1
+          }
 
-            if $all_healthy; then
-              echo "All services healthy after ${SECONDS}s."
-              break
-            fi
-
-            echo "Waiting for services... (${SECONDS}s elapsed)"
-            sleep 5
-          done
-
-          if ! $all_healthy; then
-            echo "Timed out waiting for services to become healthy."
-            docker compose -f e2e/docker-compose.yml ps
-            exit 1
-          fi
+          wait_for_http keycloak  "http://localhost:8081/realms/test"
+          wait_for_http mas       "http://localhost:8082/.well-known/openid-configuration"
+          wait_for_http mailpit   "http://localhost:8025/api/v1/messages"
+          echo "All services ready."
 
       - name: Build release binary
         run: cargo build --release

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -84,12 +84,8 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/.well-known/openid-configuration"]
-      interval: 10s
-      timeout: 5s
-      retries: 20
-      start_period: 20s
+    # No healthcheck: MAS is a distroless image with no shell or curl.
+    # Readiness is polled from the host in CI (see e2e.yml wait step).
 
   # ── Mailpit (fake SMTP) ───────────────────────────────────────────────────────
   # Captures all outgoing email so e2e tests can assert invite emails were sent.
@@ -100,11 +96,8 @@ services:
     ports:
       - "8025:8025"   # Web UI + REST API
       - "1025:1025"   # SMTP
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8025/api/v1/messages"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+    # No healthcheck: Mailpit's image is scratch-based with no shell or curl.
+    # Readiness is polled from the host in CI (see e2e.yml wait step).
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Problem

The nightly E2E run was timing out at "Wait for all services to become healthy" because the Docker healthchecks for MAS and Mailpit use `CMD-SHELL` with `curl`, but:
- **MAS** (`ghcr.io/element-hq/matrix-authentication-service:0.12.0`) is a distroless image — no shell, no curl
- **Mailpit** (`axllent/mailpit:latest`) is scratch-based — no shell, no curl

Both containers started and served traffic correctly, but reported `unhealthy` forever, causing the wait loop to time out after 300s.

## Fix

- Remove the broken in-container healthchecks from MAS and Mailpit in `docker-compose.yml`
- Replace Docker health status polling in `e2e.yml` and `security.yml` with direct HTTP polling from the runner against the exposed host ports (Keycloak → MAS → Mailpit in dependency order)

## Test plan

- [ ] Trigger E2E workflow manually after merge — should pass the wait step and proceed to run tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)