### PR TITLE
refactor(delete): extract delete workflow into services layer

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -4,12 +4,11 @@ use axum::{
     Form,
 };
 use serde::Deserialize;
-use serde_json::json;
 
 use crate::{
     auth::{csrf::validate, session::AuthenticatedAdmin},
     error::AppError,
-    models::audit::AuditResult,
+    services::delete_user::delete_user,
     state::AppState,
 };
 
@@ -20,10 +19,11 @@ pub struct DeleteUserForm {
 
 /// POST /users/{id}/delete
 ///
-/// Deletes the user from both Keycloak and MAS (if a MAS account exists).
-/// MAS is attempted first so that if it fails the Keycloak record is preserved
-/// and the admin can retry. Both deletions are audit-logged.
-pub async fn delete_user(
+/// Deactivates the MAS account then deletes the Keycloak user. MAS is
+/// attempted first so that a failure leaves the Keycloak record intact
+/// and the admin can retry. Both operations are audit-logged. On success,
+/// redirects to the user search page.
+pub async fn delete_user_handler(
     AuthenticatedAdmin(admin): AuthenticatedAdmin,
     State(state): State<AppState>,
     Path(keycloak_id): Path<String>,
@@ -31,77 +31,16 @@ pub async fn delete_user(
 ) -> Result<impl IntoResponse, AppError> {
     validate(&admin.csrf_token, &form._csrf)?;
 
-    // Resolve username and MAS ID before deleting anything.
-    let kc_user = state.keycloak.get_user(&keycloak_id).await?;
-    let username = kc_user.username.clone();
-    let matrix_user_id = format!("@{}:{}", username, state.config.homeserver_domain);
-
-    let mas_user = state
-        .mas
-        .get_user_by_username(&username)
-        .await
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "MAS user lookup failed during delete");
-            None
-        });
-
-    // ── Deactivate MAS user first (if present) ───────────────────────────────
-    // Note: MAS deactivation revokes sessions but does not free the email address.
-    // See the TODO in MasClient::delete_user for the permanent solution.
-    if let Some(ref mas) = mas_user {
-        let mas_result = state.mas.delete_user(&mas.id).await;
-        let audit_result = if mas_result.is_ok() {
-            AuditResult::Success
-        } else {
-            AuditResult::Failure
-        };
-
-        state
-            .audit
-            .log(
-                &admin.subject,
-                &admin.username,
-                Some(&keycloak_id),
-                Some(&matrix_user_id),
-                "deactivate_mas_user",
-                audit_result,
-                json!({
-                    "keycloak_user_id": keycloak_id,
-                    "mas_user_id": mas.id,
-                    "username": username,
-                }),
-            )
-            .await?;
-
-        mas_result?;
-    }
-
-    // ── Delete Keycloak user ──────────────────────────────────────────────────
-    let kc_result = state.keycloak.delete_user(&keycloak_id).await;
-    let audit_result = if kc_result.is_ok() {
-        AuditResult::Success
-    } else {
-        AuditResult::Failure
-    };
-
-    state
-        .audit
-        .log(
-            &admin.subject,
-            &admin.username,
-            Some(&keycloak_id),
-            Some(&matrix_user_id),
-            "delete_keycloak_user",
-            audit_result,
-            json!({
-                "keycloak_user_id": keycloak_id,
-                "username": username,
-                "mas_deleted": mas_user.is_some(),
-            }),
-        )
-        .await?;
-
-    kc_result?;
+    delete_user(
+        &keycloak_id,
+        state.keycloak.as_ref(),
+        state.mas.as_ref(),
+        &state.audit,
+        &admin.subject,
+        &admin.username,
+        &state.config.homeserver_domain,
+    )
+    .await?;
 
     Ok(Redirect::to("/users/search"))
 }
@@ -164,6 +103,8 @@ mod tests {
             .unwrap()
     }
 
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn delete_with_mas_account_redirects_to_search() {
         let state = build_test_state_full(
@@ -205,13 +146,9 @@ mod tests {
 
     #[tokio::test]
     async fn delete_keycloak_user_not_found_returns_404() {
-        let state = build_test_state_full(
-            MockKeycloak::default(), // no users → get_user returns NotFound
-            MockMas::default(),
-            "secret",
-            None,
-        )
-        .await;
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
         let cookie = make_auth_cookie(TEST_CSRF);
         let resp = post_delete(state, "nonexistent", TEST_CSRF, Some(&cookie)).await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -246,7 +183,6 @@ mod tests {
             None,
         )
         .await;
-        // No cookie → AuthenticatedAdmin redirects to /auth/login
         let resp = post_delete(state, "kc-123", TEST_CSRF, None).await;
         assert_eq!(resp.status(), StatusCode::SEE_OTHER);
         assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
@@ -293,8 +229,6 @@ mod tests {
 
     #[tokio::test]
     async fn delete_mas_lookup_failure_still_deletes_keycloak_user() {
-        // When MAS lookup fails, the handler logs a warning and treats it as no
-        // MAS account — skips MAS deletion and proceeds to delete the Keycloak user.
         let state = build_test_state_full(
             MockKeycloak {
                 users: vec![test_kc_user()],
@@ -310,15 +244,12 @@ mod tests {
         .await;
         let cookie = make_auth_cookie(TEST_CSRF);
         let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
-        // Should succeed (redirect to /users/search), Keycloak user deleted.
         assert_eq!(resp.status(), StatusCode::SEE_OTHER);
         assert_eq!(resp.headers().get("location").unwrap(), "/users/search");
     }
 
     #[tokio::test]
     async fn delete_success_writes_audit_logs() {
-        // With a MAS account the handler writes two entries: deactivate_mas_user
-        // and delete_keycloak_user. Both should be recorded against kc-123.
         let state = build_test_state_full(
             MockKeycloak {
                 users: vec![test_kc_user()],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,10 @@ pub fn build_router(state: AppState) -> Router {
             "/users/{id}/keycloak/logout",
             post(handlers::devices::force_keycloak_logout),
         )
-        .route("/users/{id}/delete", post(handlers::delete::delete_user))
+        .route(
+            "/users/{id}/delete",
+            post(handlers::delete::delete_user_handler),
+        )
         .route("/users/{id}/disable", post(handlers::disable::disable))
         // Admin invite (OIDC session + CSRF)
         .route("/users/invite", post(handlers::invite::admin_invite))

--- a/src/services/delete_user.rs
+++ b/src/services/delete_user.rs
@@ -1,0 +1,422 @@
+use serde_json::json;
+
+use crate::{
+    clients::{KeycloakApi, MasApi},
+    error::AppError,
+    models::audit::AuditResult,
+    services::AuditService,
+};
+
+/// Delete a user account from Keycloak and MAS.
+///
+/// Steps:
+///   1. Fetch the Keycloak user to resolve the username and Matrix ID.
+///   2. Look up the MAS user by username (non-fatal if missing or unreachable).
+///   3. Deactivate the MAS account (fatal — audit-logged; if this fails the
+///      Keycloak record is preserved so the admin can retry).
+///   4. Delete the Keycloak user (fatal — audit-logged).
+pub async fn delete_user(
+    keycloak_id: &str,
+    keycloak: &dyn KeycloakApi,
+    mas: &dyn MasApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+    homeserver_domain: &str,
+) -> Result<(), AppError> {
+    let kc_user = keycloak.get_user(keycloak_id).await?;
+    let username = &kc_user.username;
+    let matrix_user_id = format!("@{}:{}", username, homeserver_domain);
+
+    // ── Deactivate MAS user first (if present) ────────────────────────────────
+    // MAS is attempted before Keycloak so that if it fails the Keycloak record
+    // is preserved and the admin can retry cleanly.
+    let mas_user = mas
+        .get_user_by_username(username)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "MAS user lookup failed during delete; skipping MAS deactivation");
+            None
+        });
+
+    if let Some(ref mas_user) = mas_user {
+        let mas_result = mas.delete_user(&mas_user.id).await;
+        let audit_result = if mas_result.is_ok() {
+            AuditResult::Success
+        } else {
+            AuditResult::Failure
+        };
+
+        audit
+            .log(
+                admin_subject,
+                admin_username,
+                Some(keycloak_id),
+                Some(&matrix_user_id),
+                "deactivate_mas_user",
+                audit_result,
+                json!({
+                    "keycloak_user_id": keycloak_id,
+                    "mas_user_id": mas_user.id,
+                    "username": username,
+                }),
+            )
+            .await?;
+
+        mas_result?;
+    }
+
+    // ── Delete Keycloak user ──────────────────────────────────────────────────
+    let kc_result = keycloak.delete_user(keycloak_id).await;
+    let audit_result = if kc_result.is_ok() {
+        AuditResult::Success
+    } else {
+        AuditResult::Failure
+    };
+
+    audit
+        .log(
+            admin_subject,
+            admin_username,
+            Some(keycloak_id),
+            Some(&matrix_user_id),
+            "delete_keycloak_user",
+            audit_result,
+            json!({
+                "keycloak_user_id": keycloak_id,
+                "username": username,
+                "mas_deleted": mas_user.is_some(),
+            }),
+        )
+        .await?;
+
+    kc_result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    use super::*;
+    use crate::{
+        clients::{KeycloakApi, MasApi},
+        models::{
+            keycloak::{KeycloakGroup, KeycloakRole, KeycloakUser},
+            mas::{MasSession, MasUser},
+        },
+        services::AuditService,
+    };
+
+    // ── Test helpers ──────────────────────────────────────────────────────────
+
+    async fn audit_svc() -> AuditService {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        AuditService::new(pool)
+    }
+
+    fn kc_user(id: &str, username: &str) -> KeycloakUser {
+        KeycloakUser {
+            id: id.to_string(),
+            username: username.to_string(),
+            email: Some(format!("{username}@example.com")),
+            first_name: None,
+            last_name: None,
+            enabled: true,
+            email_verified: true,
+            created_timestamp: None,
+            required_actions: vec![],
+        }
+    }
+
+    fn mas_user(username: &str) -> MasUser {
+        MasUser {
+            id: "mas-001".to_string(),
+            username: username.to_string(),
+            deactivated_at: None,
+        }
+    }
+
+    // ── Mock Keycloak ─────────────────────────────────────────────────────────
+
+    struct MockKc {
+        user: Option<KeycloakUser>,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl KeycloakApi for MockKc {
+        async fn search_users(
+            &self,
+            _: &str,
+            _: u32,
+            _: u32,
+        ) -> Result<Vec<KeycloakUser>, AppError> {
+            Ok(vec![])
+        }
+        async fn count_users(&self, _: &str) -> Result<u32, AppError> {
+            Ok(0)
+        }
+        async fn get_user(&self, _: &str) -> Result<KeycloakUser, AppError> {
+            self.user
+                .clone()
+                .ok_or_else(|| AppError::NotFound("not found".into()))
+        }
+        async fn get_user_by_email(&self, _: &str) -> Result<Option<KeycloakUser>, AppError> {
+            Ok(None)
+        }
+        async fn get_user_groups(&self, _: &str) -> Result<Vec<KeycloakGroup>, AppError> {
+            Ok(vec![])
+        }
+        async fn get_user_roles(&self, _: &str) -> Result<Vec<KeycloakRole>, AppError> {
+            Ok(vec![])
+        }
+        async fn logout_user(&self, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn create_user(&self, _: &str, _: &str) -> Result<String, AppError> {
+            Ok("id".into())
+        }
+        async fn send_invite_email(&self, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_delete {
+                Err(AppError::Upstream {
+                    service: "keycloak".into(),
+                    message: "mock delete failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn disable_user(&self, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    // ── Mock MAS ──────────────────────────────────────────────────────────────
+
+    #[derive(Default)]
+    struct MockMs {
+        user: Option<MasUser>,
+        fail_lookup: bool,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl MasApi for MockMs {
+        async fn get_user_by_username(&self, _: &str) -> Result<Option<MasUser>, AppError> {
+            if self.fail_lookup {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock lookup failure".into(),
+                })
+            } else {
+                Ok(self.user.clone())
+            }
+        }
+        async fn list_sessions(&self, _: &str) -> Result<Vec<MasSession>, AppError> {
+            Ok(vec![])
+        }
+        async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_delete {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock delete failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_succeeds_with_no_mas_user() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs::default());
+
+        delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "delete_keycloak_user");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn delete_deactivates_mas_then_deletes_keycloak() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs {
+            user: Some(mas_user("alice")),
+            ..Default::default()
+        });
+
+        delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 2);
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"deactivate_mas_user"));
+        assert!(actions.contains(&"delete_keycloak_user"));
+        assert!(logs.iter().all(|l| l.result == "success"));
+    }
+
+    #[tokio::test]
+    async fn delete_mas_failure_aborts_before_keycloak_and_is_logged() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs {
+            user: Some(mas_user("alice")),
+            fail_delete: true,
+            ..Default::default()
+        });
+
+        let result = delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        // Only the MAS deactivation is logged — Keycloak delete was not attempted.
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "deactivate_mas_user");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    #[tokio::test]
+    async fn delete_keycloak_failure_is_logged_and_returned() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: true,
+        });
+        let mas = Arc::new(MockMs::default());
+
+        let result = delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs[0].action, "delete_keycloak_user");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    #[tokio::test]
+    async fn delete_mas_lookup_failure_is_non_fatal() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs {
+            fail_lookup: true,
+            ..Default::default()
+        });
+
+        delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        // MAS lookup failed non-fatally — only the Keycloak delete is logged.
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "delete_keycloak_user");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn delete_keycloak_user_not_found_returns_error() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: None,
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs::default());
+
+        let result = delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await;
+
+        assert!(result.is_err());
+        // Failed before any audit log was written.
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert!(logs.is_empty());
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_service;
+pub mod delete_user;
 pub mod disable_user;
 pub mod identity_mapper;
 pub mod user_service;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -407,7 +407,7 @@ pub fn mutations_router(state: AppState) -> Router {
         )
         .route(
             "/users/{id}/delete",
-            post(crate::handlers::delete::delete_user),
+            post(crate::handlers::delete::delete_user_handler),
         )
         .route(
             "/users/{id}/disable",


### PR DESCRIPTION
## Summary

- Extracts multi-step delete logic from `handlers/delete.rs` into `services/delete_user.rs`
- Completes the workflow extraction started in PR #28 (invite) and the earlier disable workflow
- All three non-trivial workflows (`invite_user`, `disable_user`, `delete_user`) now live in the services layer with explicit deps and no `AppState`
- Adds 6 unit tests directly on the service function

## Test plan

- [ ] 150 unit tests pass (`cargo test`)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt` clean
- [ ] Handler tests still cover the full HTTP layer
- [ ] E2E CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)