### PR TITLE
feat(dashboard): add system status card

### DIFF
--- a/src/handlers/dashboard.rs
+++ b/src/handlers/dashboard.rs
@@ -1,7 +1,8 @@
 use askama::Template;
 use axum::{
     extract::{Query, State},
-    response::Html,
+    http::header,
+    response::{Html, IntoResponse},
 };
 use serde::Deserialize;
 
@@ -72,11 +73,58 @@ pub async fn dashboard(
     Ok(Html(html))
 }
 
+#[derive(Template)]
+#[template(path = "status_card.html")]
+struct StatusCardTemplate {
+    keycloak_ok: bool,
+    mas_ok: bool,
+    synapse_configured: bool,
+    user_count: Option<u32>,
+}
+
+/// GET /status
+///
+/// Returns an HTML fragment with the current system status.
+/// Intended to be loaded via HTMX on the dashboard — runs health checks
+/// against each configured upstream.
+pub async fn status(
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    // Keycloak: try count_users — cheap read-only call
+    let (keycloak_ok, user_count) = match state.keycloak.count_users("").await {
+        Ok(n) => (true, Some(n)),
+        Err(_) => (false, None),
+    };
+
+    // MAS: try get_user_by_username with a sentinel — returns Ok(None) when healthy
+    let mas_ok = state
+        .mas
+        .get_user_by_username("__status_check__")
+        .await
+        .is_ok();
+
+    let synapse_configured = state.synapse.is_some();
+
+    let tmpl = StatusCardTemplate {
+        keycloak_ok,
+        mas_ok,
+        synapse_configured,
+        user_count,
+    };
+    let html = tmpl
+        .render()
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("Template error: {e}")))?;
+    Ok(([(header::CONTENT_TYPE, "text/html; charset=utf-8")], html))
+}
+
 #[cfg(test)]
 mod tests {
     use axum::{
         body::Body,
         http::{Method, Request, StatusCode},
+        routing::get,
+        Router,
     };
     use http_body_util::BodyExt;
     use tower::ServiceExt;
@@ -87,6 +135,12 @@ mod tests {
             build_test_state, dashboard_router, make_auth_cookie, MockKeycloak, TEST_CSRF,
         },
     };
+
+    fn status_router(state: crate::state::AppState) -> Router {
+        Router::new()
+            .route("/status", get(super::status))
+            .with_state(state)
+    }
 
     async fn get_dashboard(
         state: crate::state::AppState,
@@ -200,6 +254,85 @@ mod tests {
         assert!(
             body.contains("Something went wrong"),
             "expected error message in body"
+        );
+    }
+
+    // ── Status handler tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn status_unauthenticated_redirects_to_login() {
+        let state = build_test_state(MockKeycloak::default(), "secret", None).await;
+        let resp = status_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn status_authenticated_returns_html_fragment() {
+        let state = build_test_state(MockKeycloak::default(), "secret", None).await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = status_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/status")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("text/html"));
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("status-grid"));
+    }
+
+    #[tokio::test]
+    async fn status_shows_keycloak_user_count() {
+        let state = build_test_state(
+            MockKeycloak {
+                user_count: 7,
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = status_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/status")
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains("7"),
+            "expected user count '7' in status fragment"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub fn build_router(state: AppState) -> Router {
         .nest_service("/static", ServeDir::new("static"))
         // Dashboard
         .route("/", get(handlers::dashboard::dashboard))
+        .route("/status", get(handlers::dashboard::status))
         // User search & detail
         .route("/users/search", get(handlers::users::search))
         .route("/users/{id}", get(handlers::users::detail))

--- a/static/app.css
+++ b/static/app.css
@@ -149,3 +149,30 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
 .login-box { background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; padding: 2.5rem; text-align: center; max-width: 360px; width: 100%; }
 .login-box h1 { font-size: 20px; margin-bottom: 0.5rem; }
 .login-box p { color: #555; margin-bottom: 1.5rem; }
+
+/* ── Status card ─────────────────────────────────────────────────────────── */
+.status-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.status-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  min-width: 140px;
+  background: var(--surface, #f5f5f5);
+}
+.status-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted, #888);
+}
+.status-value { font-weight: 600; }
+.status-sub { font-size: 0.8rem; color: var(--muted, #888); }
+.status-ok .status-value { color: #2a9d3c; }
+.status-err .status-value { color: #c0392b; }
+.status-warn .status-value { color: #e67e22; }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -15,6 +15,13 @@
   <h1>Dashboard</h1>
 </div>
 
+<div class="card" style="margin-bottom:1rem">
+  <h2>System Status</h2>
+  <div hx-get="/status" hx-trigger="load" hx-swap="innerHTML">
+    <p class="muted">Checking status&hellip;</p>
+  </div>
+</div>
+
 <div class="stats-grid">
   <div class="stat-card">
     <div class="stat-value">{{ total_users }}</div>

--- a/templates/status_card.html
+++ b/templates/status_card.html
@@ -1,0 +1,15 @@
+<div class="status-grid">
+  <div class="status-item {% if keycloak_ok %}status-ok{% else %}status-err{% endif %}">
+    <span class="status-label">Keycloak</span>
+    <span class="status-value">{% if keycloak_ok %}&#9679;  reachable{% else %}&#9679;  unreachable{% endif %}</span>
+    {% if let Some(n) = user_count %}<span class="status-sub">{{ n }} users</span>{% endif %}
+  </div>
+  <div class="status-item {% if mas_ok %}status-ok{% else %}status-err{% endif %}">
+    <span class="status-label">MAS</span>
+    <span class="status-value">{% if mas_ok %}&#9679;  reachable{% else %}&#9679;  unreachable{% endif %}</span>
+  </div>
+  <div class="status-item {% if synapse_configured %}status-ok{% else %}status-warn{% endif %}">
+    <span class="status-label">Synapse</span>
+    <span class="status-value">{% if synapse_configured %}&#9679;  configured{% else %}&#9679;  not configured{% endif %}</span>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds `GET /status` returning an HTMX HTML fragment with upstream service status
- Dashboard lazy-loads the status card via `hx-get="/status" hx-trigger="load"` — page renders immediately, status populates after
- Shows Keycloak reachability + user count, MAS reachability, Synapse configured/not
- Auth-protected — redirects to login if unauthenticated

## Test plan
- [ ] `cargo test` passes (3 new status handler tests)
- [ ] Dashboard loads immediately, status card populates after
- [ ] Shows correct status when all services up
- [ ] Keycloak unreachable → red indicator, no blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)