### PR TITLE
docs: add NOTE comments on architectural boundary decisions

### DIFF
--- a/src/models/workflow.rs
+++ b/src/models/workflow.rs
@@ -10,6 +10,9 @@
 /// which sessions were not cleaned up.
 #[derive(Debug, Default)]
 pub struct WorkflowOutcome {
+    // NOTE: Warnings are free-form strings intentionally. Structured error codes
+    // with machine-readable keys are deferred to Phase 3 to support admin
+    // automations. See AGENTS.md Phase 3 roadmap.
     pub warnings: Vec<String>,
 }
 

--- a/src/services/identity_mapper.rs
+++ b/src/services/identity_mapper.rs
@@ -4,6 +4,9 @@ use crate::models::{keycloak::KeycloakUser, unified::CorrelationStatus};
 /// MAS account and Matrix identity.
 #[derive(Debug, Clone)]
 pub struct MappedIdentity {
+    // NOTE: KeycloakUser is a connector type stored here as a convenience. This is
+    // a known layer boundary violation tracked in issue #40. Once CanonicalUser is
+    // extracted, this field should be replaced with it.
     pub keycloak_user: KeycloakUser,
     /// Derived Matrix user ID, e.g. `@alice:example.com`.
     /// Convention: `@{keycloak_username}:{homeserver_domain}`.

--- a/src/services/reconcile_membership.rs
+++ b/src/services/reconcile_membership.rs
@@ -57,6 +57,9 @@ pub async fn reconcile_membership(
             } else {
                 AuditResult::Failure
             };
+            // NOTE: Audit failures are intentionally non-fatal here. Per-room reconciliation
+            // already surfaces partial failures via WorkflowOutcome warnings; losing an
+            // audit entry is less harmful than aborting the entire reconciliation run.
             let _ = audit
                 .log(
                     actor_subject,
@@ -90,6 +93,9 @@ pub async fn reconcile_membership(
             } else {
                 AuditResult::Failure
             };
+            // NOTE: Audit failures are intentionally non-fatal here. Per-room reconciliation
+            // already surfaces partial failures via WorkflowOutcome warnings; losing an
+            // audit entry is less harmful than aborting the entire reconciliation run.
             let _ = audit
                 .log(
                     actor_subject,


### PR DESCRIPTION
## Summary

- Adds `// NOTE:` comment on `MappedIdentity.keycloak_user` documenting the known layer boundary violation (tracked in #40) — `KeycloakUser` is a connector type held here as a convenience until `CanonicalUser` is extracted.
- Adds `// NOTE:` comments before both `let _ = audit.log(...)` calls in `reconcile_membership` explaining that audit failures are intentionally non-fatal, and why that trade-off was made.
- Adds `// NOTE:` comment on `WorkflowOutcome.warnings` documenting that free-form strings are intentional, with structured error codes deferred to Phase 3.

## Test plan

- [ ] `cargo fmt` — no changes (comments only)
- [ ] `cargo clippy --all-targets -- -D warnings` — passes, no new warnings
- [ ] `cargo test` — all tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)