### PR TITLE
refactor(clients): extract RoomManagementApi trait

### DIFF
--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,7 +1,9 @@
 pub mod keycloak;
 pub mod mas;
+pub mod room_management;
 pub mod synapse;
 
 pub use keycloak::{KeycloakApi, KeycloakClient};
 pub use mas::{MasApi, MasClient};
+pub use room_management::RoomManagementApi;
 pub use synapse::{SynapseApi, SynapseClient};

--- a/src/clients/room_management.rs
+++ b/src/clients/room_management.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+
+use crate::error::AppError;
+
+/// Abstraction over Matrix room membership enforcement operations.
+///
+/// Implemented by [`crate::clients::SynapseClient`] today; future Matrix server
+/// connectors (Dendrite, proxy gateways) implement this trait without needing to
+/// implement the full Synapse admin API surface.
+#[async_trait]
+pub trait RoomManagementApi: Send + Sync {
+    /// Returns the Matrix IDs of all current members of the given room.
+    async fn get_joined_members(&self, room_id: &str) -> Result<Vec<String>, AppError>;
+
+    /// Force-joins `user_id` into `room_id` via the server admin API.
+    ///
+    /// The user is added immediately without requiring an invite acceptance.
+    async fn force_join_user(&self, user_id: &str, room_id: &str) -> Result<(), AppError>;
+
+    /// Kicks `user_id` from `room_id` with the given reason string.
+    ///
+    /// The admin user must already be a member of the room when using the
+    /// Matrix client API kick endpoint.
+    async fn kick_user(&self, user_id: &str, room_id: &str, reason: &str) -> Result<(), AppError>;
+}

--- a/src/clients/synapse.rs
+++ b/src/clients/synapse.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::{
+    clients::room_management::RoomManagementApi,
     config::SynapseConfig,
     error::{upstream_error, AppError},
     models::synapse::{SynapseDevice, SynapseUser},
@@ -280,6 +281,22 @@ impl SynapseApi for SynapseClient {
             .map_err(|e| upstream_error("synapse", e))?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl RoomManagementApi for SynapseClient {
+    async fn get_joined_members(&self, room_id: &str) -> Result<Vec<String>, AppError> {
+        self.get_joined_room_members(room_id).await
+    }
+
+    async fn force_join_user(&self, user_id: &str, room_id: &str) -> Result<(), AppError> {
+        // Delegate to the SynapseApi impl — same HTTP call.
+        <Self as SynapseApi>::force_join_user(self, user_id, room_id).await
+    }
+
+    async fn kick_user(&self, user_id: &str, room_id: &str, reason: &str) -> Result<(), AppError> {
+        self.kick_user_from_room(user_id, room_id, reason).await
     }
 }
 

--- a/src/handlers/bulk_reconcile.rs
+++ b/src/handlers/bulk_reconcile.rs
@@ -42,7 +42,7 @@ pub async fn bulk_reconcile(
 ) -> Result<impl IntoResponse, AppError> {
     validate(&admin.csrf_token, &form._csrf)?;
 
-    let synapse = state.synapse.as_ref().ok_or_else(|| {
+    let room_mgmt = state.room_mgmt.as_ref().ok_or_else(|| {
         AppError::NotFound("Synapse is not configured — reconciliation is unavailable".into())
     })?;
 
@@ -90,7 +90,7 @@ pub async fn bulk_reconcile(
             &matrix_user_id,
             &state.policy,
             &group_names,
-            synapse.as_ref(),
+            room_mgmt.as_ref(),
             &state.audit,
             &admin.subject,
             &admin.username,

--- a/src/handlers/reconcile.rs
+++ b/src/handlers/reconcile.rs
@@ -37,7 +37,7 @@ pub async fn reconcile(
 ) -> Result<impl IntoResponse, AppError> {
     validate(&admin.csrf_token, &form._csrf)?;
 
-    let synapse = state.synapse.as_ref().ok_or_else(|| {
+    let room_mgmt = state.room_mgmt.as_ref().ok_or_else(|| {
         AppError::NotFound("Synapse is not configured — reconciliation is unavailable".into())
     })?;
 
@@ -52,7 +52,7 @@ pub async fn reconcile(
         &matrix_user_id,
         &state.policy,
         &group_names,
-        synapse.as_ref(),
+        room_mgmt.as_ref(),
         &state.audit,
         &admin.subject,
         &admin.username,
@@ -102,7 +102,7 @@ pub async fn reconcile_preview(
 ) -> Result<impl IntoResponse, AppError> {
     validate(&admin.csrf_token, &form._csrf)?;
 
-    let synapse = state.synapse.as_ref().ok_or_else(|| {
+    let room_mgmt = state.room_mgmt.as_ref().ok_or_else(|| {
         AppError::NotFound("Synapse is not configured — reconciliation is unavailable".into())
     })?;
 
@@ -116,7 +116,7 @@ pub async fn reconcile_preview(
         &matrix_user_id,
         &state.policy,
         &group_names,
-        synapse.as_ref(),
+        room_mgmt.as_ref(),
         state.config.reconcile_remove_from_rooms,
     )
     .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use axum_extra::extract::cookie::Key;
 use sha2::{Digest, Sha512};
 use tower_http::{services::ServeDir, timeout::TimeoutLayer};
 
-use clients::{KeycloakClient, MasClient, SynapseClient};
+use clients::{KeycloakClient, MasClient, RoomManagementApi, SynapseClient};
 use config::Config;
 use models::policy::PolicyEngine;
 use services::{AuditService, UserService};
@@ -40,10 +40,19 @@ pub async fn build_state(config: &Config) -> anyhow::Result<AppState> {
     let keycloak: Arc<dyn clients::KeycloakApi> =
         Arc::new(KeycloakClient::new(config.keycloak.clone()));
     let mas: Arc<dyn clients::MasApi> = Arc::new(MasClient::new(config.mas.clone()));
-    let synapse: Option<Arc<dyn clients::SynapseApi>> = config
+
+    // Build the Synapse client once and cast to both trait objects so that both
+    // `synapse` (Synapse-specific ops) and `room_mgmt` (reconciliation) share
+    // the same underlying client and token cache.
+    let synapse_client = config
         .synapse
         .as_ref()
-        .map(|c| -> Arc<dyn clients::SynapseApi> { Arc::new(SynapseClient::new(c.clone())) });
+        .map(|c| Arc::new(SynapseClient::new(c.clone())));
+    let synapse: Option<Arc<dyn clients::SynapseApi>> = synapse_client
+        .as_ref()
+        .map(|c| Arc::clone(c) as Arc<dyn clients::SynapseApi>);
+    let room_mgmt: Option<Arc<dyn RoomManagementApi>> =
+        synapse_client.map(|c| c as Arc<dyn RoomManagementApi>);
 
     let oidc = auth::oidc::OidcClient::init(&config.oidc, &config.required_admin_role).await?;
 
@@ -66,6 +75,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<AppState> {
         keycloak,
         mas,
         synapse,
+        room_mgmt,
         users,
         audit,
         policy,

--- a/src/services/reconcile_membership.rs
+++ b/src/services/reconcile_membership.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clients::SynapseApi,
+    clients::RoomManagementApi,
     error::AppError,
     models::{audit::AuditResult, policy::PolicyEngine, workflow::WorkflowOutcome},
     services::audit_service::AuditService,
@@ -21,7 +21,7 @@ pub async fn reconcile_membership(
     matrix_user_id: &str,
     policy: &PolicyEngine,
     keycloak_groups: &[String],
-    synapse: &dyn SynapseApi,
+    synapse: &dyn RoomManagementApi,
     audit: &AuditService,
     actor_subject: &str,
     actor_username: &str,
@@ -32,10 +32,7 @@ pub async fn reconcile_membership(
     for mapping in policy.all_mappings() {
         let in_group = keycloak_groups.contains(&mapping.keycloak_group);
 
-        let members = match synapse
-            .get_joined_room_members(&mapping.matrix_room_id)
-            .await
-        {
+        let members = match synapse.get_joined_members(&mapping.matrix_room_id).await {
             Ok(m) => m,
             Err(e) => {
                 outcome.add_warning(format!(
@@ -82,7 +79,7 @@ pub async fn reconcile_membership(
             }
         } else if remove_from_rooms && !in_group && in_room {
             let result = synapse
-                .kick_user_from_room(
+                .kick_user(
                     matrix_user_id,
                     &mapping.matrix_room_id,
                     "Removed from Keycloak group",
@@ -150,7 +147,7 @@ pub async fn preview_membership(
     matrix_user_id: &str,
     policy: &PolicyEngine,
     keycloak_groups: &[String],
-    synapse: &dyn SynapseApi,
+    synapse: &dyn RoomManagementApi,
     remove_from_rooms: bool,
 ) -> Result<ReconcilePreview, AppError> {
     let mut preview = ReconcilePreview::default();
@@ -158,10 +155,7 @@ pub async fn preview_membership(
     for mapping in policy.all_mappings() {
         let in_group = keycloak_groups.contains(&mapping.keycloak_group);
 
-        let members = match synapse
-            .get_joined_room_members(&mapping.matrix_room_id)
-            .await
-        {
+        let members = match synapse.get_joined_members(&mapping.matrix_room_id).await {
             Ok(m) => m,
             Err(e) => {
                 preview.warnings.push(format!(
@@ -196,15 +190,12 @@ mod tests {
 
     use super::*;
     use crate::{
-        models::{
-            group_mapping::GroupMapping,
-            policy::PolicyEngine,
-            synapse::{SynapseDevice, SynapseUser},
-        },
+        clients::RoomManagementApi,
+        models::{group_mapping::GroupMapping, policy::PolicyEngine},
         services::audit_service::AuditService,
     };
 
-    // ── Mock Synapse ─────────────────────────────────────────────────────────
+    // ── Mock RoomManagement ───────────────────────────────────────────────────
 
     #[derive(Default)]
     struct MockSynapse {
@@ -219,18 +210,8 @@ mod tests {
     }
 
     #[async_trait]
-    impl SynapseApi for MockSynapse {
-        async fn get_user(&self, _: &str) -> Result<Option<SynapseUser>, AppError> {
-            unimplemented!()
-        }
-        async fn list_devices(&self, _: &str) -> Result<Vec<SynapseDevice>, AppError> {
-            unimplemented!()
-        }
-        async fn delete_device(&self, _: &str, _: &str) -> Result<(), AppError> {
-            unimplemented!()
-        }
-
-        async fn get_joined_room_members(&self, _room_id: &str) -> Result<Vec<String>, AppError> {
+    impl RoomManagementApi for MockSynapse {
+        async fn get_joined_members(&self, _room_id: &str) -> Result<Vec<String>, AppError> {
             if self.fail_get_members {
                 return Err(AppError::Upstream {
                     service: "synapse".into(),
@@ -251,7 +232,7 @@ mod tests {
             Ok(())
         }
 
-        async fn kick_user_from_room(
+        async fn kick_user(
             &self,
             user_id: &str,
             _room_id: &str,

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 
 use crate::{
     auth::oidc::OidcClient,
-    clients::{KeycloakApi, MasApi, SynapseApi},
+    clients::{KeycloakApi, MasApi, RoomManagementApi, SynapseApi},
     config::Config,
     models::policy::PolicyEngine,
     services::{AuditService, UserService},
@@ -20,8 +20,11 @@ pub struct AppState {
     pub keycloak: Arc<dyn KeycloakApi>,
     pub mas: Arc<dyn MasApi>,
     /// Optional Synapse connector. `None` when `SYNAPSE_*` env vars are absent.
-    /// Group membership reconciliation is disabled when this is `None`.
     pub synapse: Option<Arc<dyn SynapseApi>>,
+    /// Room membership enforcement abstraction, backed by `SynapseClient` when
+    /// Synapse is configured. `None` when Synapse is not configured — reconciliation
+    /// is disabled in that case.
+    pub room_mgmt: Option<Arc<dyn RoomManagementApi>>,
     pub users: Arc<UserService>,
     pub audit: Arc<AuditService>,
     /// Group → room membership policy built from `GROUP_MAPPINGS` config at startup.

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -8,7 +8,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 use crate::{
     auth::oidc::OidcClient,
     auth::session::AdminSession,
-    clients::{KeycloakApi, MasApi, SynapseApi},
+    clients::{KeycloakApi, MasApi, RoomManagementApi, SynapseApi},
     config::{Config, KeycloakConfig, MasConfig, OidcConfig},
     error::AppError,
     models::{
@@ -295,6 +295,44 @@ impl SynapseApi for MockSynapse {
     }
 }
 
+#[async_trait]
+impl RoomManagementApi for MockSynapse {
+    async fn get_joined_members(&self, _room_id: &str) -> Result<Vec<String>, AppError> {
+        if self.fail_get_members {
+            return Err(AppError::Upstream {
+                service: "synapse".into(),
+                message: "mock member fetch failure".into(),
+            });
+        }
+        Ok(self.members.clone())
+    }
+
+    async fn force_join_user(&self, _user_id: &str, _room_id: &str) -> Result<(), AppError> {
+        if self.fail_force_join {
+            return Err(AppError::Upstream {
+                service: "synapse".into(),
+                message: "mock force_join failure".into(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn kick_user(
+        &self,
+        _user_id: &str,
+        _room_id: &str,
+        _reason: &str,
+    ) -> Result<(), AppError> {
+        if self.fail_kick {
+            return Err(AppError::Upstream {
+                service: "synapse".into(),
+                message: "mock kick failure".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
 // ── State builders ────────────────────────────────────────────────────────────
 
 /// Build an `AppState` backed by an in-memory SQLite database.
@@ -368,6 +406,7 @@ pub async fn build_test_state_full(
         keycloak,
         mas,
         synapse: None,
+        room_mgmt: None,
         users,
         audit,
         policy: Arc::new(PolicyEngine::default()),
@@ -400,7 +439,10 @@ pub async fn build_test_state_with_synapse(
     config.reconcile_remove_from_rooms = reconcile_remove_from_rooms;
     state.config = Arc::new(config);
     state.policy = Arc::new(PolicyEngine::new(group_mappings));
-    state.synapse = Some(Arc::new(synapse));
+    // Cast the same Arc to both SynapseApi and RoomManagementApi.
+    let mock = Arc::new(synapse);
+    state.synapse = Some(Arc::clone(&mock) as Arc<dyn SynapseApi>);
+    state.room_mgmt = Some(mock as Arc<dyn RoomManagementApi>);
     state
 }
 


### PR DESCRIPTION
## Summary

- Introduces `RoomManagementApi` trait in `src/clients/room_management.rs` with three methods: `get_joined_members`, `force_join_user`, `kick_user`
- `SynapseClient` implements both `SynapseApi` and `RoomManagementApi`, delegating to the same underlying HTTP calls
- `AppState` gains a `room_mgmt: Option<Arc<dyn RoomManagementApi>>` field alongside `synapse`; both are cast from the same `Arc<SynapseClient>` in `build_state`, sharing the token cache
- `reconcile_membership` and `preview_membership` workflows now take `&dyn RoomManagementApi` instead of `&dyn SynapseApi`
- All reconcile and bulk-reconcile handlers use `state.room_mgmt`; the `synapse` field is retained for any future Synapse-specific operations

## Test plan

- [ ] All 206 existing unit tests pass (`cargo test`)
- [ ] `cargo clippy --all-targets -- -D warnings` passes clean
- [ ] `cargo fmt --check` passes clean
- [ ] Reconcile handler tests (unauthenticated, invalid CSRF, no Synapse → 404, success, warning) all pass via the `MockSynapse` now implementing both `SynapseApi` and `RoomManagementApi`
- [ ] No behaviour change — pure refactor

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)