### PR TITLE
refactor(policy): introduce PolicyEngine over raw Vec<GroupMapping>

### DIFF
--- a/src/handlers/bulk_reconcile.rs
+++ b/src/handlers/bulk_reconcile.rs
@@ -88,7 +88,7 @@ pub async fn bulk_reconcile(
         let outcome = reconcile_membership(
             &kc_user.id,
             &matrix_user_id,
-            &state.config.group_mappings,
+            &state.policy,
             &group_names,
             synapse.as_ref(),
             &state.audit,

--- a/src/handlers/reconcile.rs
+++ b/src/handlers/reconcile.rs
@@ -50,7 +50,7 @@ pub async fn reconcile(
     let outcome = reconcile_membership(
         &keycloak_id,
         &matrix_user_id,
-        &state.config.group_mappings,
+        &state.policy,
         &group_names,
         synapse.as_ref(),
         &state.audit,
@@ -114,7 +114,7 @@ pub async fn reconcile_preview(
 
     let preview = preview_membership(
         &matrix_user_id,
-        &state.config.group_mappings,
+        &state.policy,
         &group_names,
         synapse.as_ref(),
         state.config.reconcile_remove_from_rooms,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use tower_http::{services::ServeDir, timeout::TimeoutLayer};
 
 use clients::{KeycloakClient, MasClient, SynapseClient};
 use config::Config;
+use models::policy::PolicyEngine;
 use services::{AuditService, UserService};
 use state::AppState;
 
@@ -53,6 +54,8 @@ pub async fn build_state(config: &Config) -> anyhow::Result<AppState> {
     ));
     let audit = Arc::new(AuditService::new(pool.clone()));
 
+    let policy = Arc::new(PolicyEngine::new(config.group_mappings.clone()));
+
     let key_material = Sha512::digest(config.session_secret.as_bytes());
     let cookie_key = Key::from(&key_material);
 
@@ -65,6 +68,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<AppState> {
         synapse,
         users,
         audit,
+        policy,
         cookie_key,
     })
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod group_mapping;
 pub mod keycloak;
 pub mod mas;
+pub mod policy;
 pub mod synapse;
 pub mod unified;
 pub mod workflow;

--- a/src/models/policy.rs
+++ b/src/models/policy.rs
@@ -1,0 +1,123 @@
+use crate::models::group_mapping::GroupMapping;
+
+/// Evaluates group membership policy to determine required Matrix room memberships.
+///
+/// Wraps the configured group → room mappings and provides query methods so
+/// callers never iterate the raw mapping slice directly.
+#[derive(Debug, Clone, Default)]
+pub struct PolicyEngine {
+    mappings: Vec<GroupMapping>,
+}
+
+impl PolicyEngine {
+    /// Create a new `PolicyEngine` from the provided group → room mappings.
+    pub fn new(mappings: Vec<GroupMapping>) -> Self {
+        Self { mappings }
+    }
+
+    /// Returns all room IDs the user should be a member of, given their current groups.
+    pub fn required_rooms_for(&self, user_groups: &[String]) -> Vec<String> {
+        self.mappings
+            .iter()
+            .filter(|m| user_groups.iter().any(|g| g == &m.keycloak_group))
+            .map(|m| m.matrix_room_id.clone())
+            .collect()
+    }
+
+    /// Returns all mappings relevant to the given user's groups.
+    pub fn mappings_for<'a>(&'a self, user_groups: &[String]) -> Vec<&'a GroupMapping> {
+        self.mappings
+            .iter()
+            .filter(|m| user_groups.iter().any(|g| g == &m.keycloak_group))
+            .collect()
+    }
+
+    /// Returns all configured mappings regardless of user groups.
+    pub fn all_mappings(&self) -> &[GroupMapping] {
+        &self.mappings
+    }
+
+    /// Returns `true` if no mappings are configured.
+    pub fn is_empty(&self) -> bool {
+        self.mappings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mapping(group: &str, room: &str) -> GroupMapping {
+        GroupMapping {
+            keycloak_group: group.to_string(),
+            matrix_room_id: room.to_string(),
+        }
+    }
+
+    // ── PolicyEngine ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn required_rooms_no_groups_returns_empty() {
+        let engine = PolicyEngine::new(vec![mapping("staff", "!room1:example.com")]);
+        let rooms = engine.required_rooms_for(&[]);
+        assert!(rooms.is_empty());
+    }
+
+    #[test]
+    fn required_rooms_matching_group_returns_room() {
+        let engine = PolicyEngine::new(vec![mapping("staff", "!room1:example.com")]);
+        let rooms = engine.required_rooms_for(&["staff".to_string()]);
+        assert_eq!(rooms, vec!["!room1:example.com"]);
+    }
+
+    #[test]
+    fn required_rooms_multiple_matches_returns_all() {
+        let engine = PolicyEngine::new(vec![
+            mapping("staff", "!room1:example.com"),
+            mapping("admins", "!room2:example.com"),
+        ]);
+        let mut rooms = engine.required_rooms_for(&["staff".to_string(), "admins".to_string()]);
+        rooms.sort();
+        assert_eq!(rooms, vec!["!room1:example.com", "!room2:example.com"]);
+    }
+
+    #[test]
+    fn required_rooms_no_match_returns_empty() {
+        let engine = PolicyEngine::new(vec![mapping("staff", "!room1:example.com")]);
+        let rooms = engine.required_rooms_for(&["other-group".to_string()]);
+        assert!(rooms.is_empty());
+    }
+
+    #[test]
+    fn mappings_for_returns_only_relevant_mappings() {
+        let engine = PolicyEngine::new(vec![
+            mapping("staff", "!room1:example.com"),
+            mapping("admins", "!room2:example.com"),
+        ]);
+        let relevant = engine.mappings_for(&["staff".to_string()]);
+        assert_eq!(relevant.len(), 1);
+        assert_eq!(relevant[0].keycloak_group, "staff");
+        assert_eq!(relevant[0].matrix_room_id, "!room1:example.com");
+    }
+
+    #[test]
+    fn all_mappings_returns_every_entry() {
+        let engine = PolicyEngine::new(vec![
+            mapping("staff", "!room1:example.com"),
+            mapping("admins", "!room2:example.com"),
+        ]);
+        assert_eq!(engine.all_mappings().len(), 2);
+    }
+
+    #[test]
+    fn is_empty_true_when_no_mappings() {
+        let engine = PolicyEngine::default();
+        assert!(engine.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_when_mappings_present() {
+        let engine = PolicyEngine::new(vec![mapping("staff", "!room1:example.com")]);
+        assert!(!engine.is_empty());
+    }
+}

--- a/src/services/reconcile_membership.rs
+++ b/src/services/reconcile_membership.rs
@@ -1,14 +1,14 @@
 use crate::{
     clients::SynapseApi,
     error::AppError,
-    models::{audit::AuditResult, group_mapping::GroupMapping, workflow::WorkflowOutcome},
+    models::{audit::AuditResult, policy::PolicyEngine, workflow::WorkflowOutcome},
     services::audit_service::AuditService,
 };
 
 /// Reconcile a single user's Matrix room membership against their Keycloak
 /// group membership, using the provided group → room policy.
 ///
-/// For each mapping:
+/// For each mapping in `policy`:
 /// - If the user is in the Keycloak group but not the room → force-join.
 /// - If `remove_from_rooms` is true and the user is in the room but not the
 ///   group → kick.
@@ -19,7 +19,7 @@ use crate::{
 pub async fn reconcile_membership(
     keycloak_id: &str,
     matrix_user_id: &str,
-    group_mappings: &[GroupMapping],
+    policy: &PolicyEngine,
     keycloak_groups: &[String],
     synapse: &dyn SynapseApi,
     audit: &AuditService,
@@ -29,7 +29,7 @@ pub async fn reconcile_membership(
 ) -> Result<WorkflowOutcome, AppError> {
     let mut outcome = WorkflowOutcome::ok();
 
-    for mapping in group_mappings {
+    for mapping in policy.all_mappings() {
         let in_group = keycloak_groups.contains(&mapping.keycloak_group);
 
         let members = match synapse
@@ -142,14 +142,14 @@ pub struct ReconcilePreview {
 /// Member-fetch failures are non-fatal: recorded in `warnings`, room is skipped.
 pub async fn preview_membership(
     matrix_user_id: &str,
-    group_mappings: &[GroupMapping],
+    policy: &PolicyEngine,
     keycloak_groups: &[String],
     synapse: &dyn SynapseApi,
     remove_from_rooms: bool,
 ) -> Result<ReconcilePreview, AppError> {
     let mut preview = ReconcilePreview::default();
 
-    for mapping in group_mappings {
+    for mapping in policy.all_mappings() {
         let in_group = keycloak_groups.contains(&mapping.keycloak_group);
 
         let members = match synapse
@@ -192,6 +192,7 @@ mod tests {
     use crate::{
         models::{
             group_mapping::GroupMapping,
+            policy::PolicyEngine,
             synapse::{SynapseDevice, SynapseUser},
         },
         services::audit_service::AuditService,
@@ -278,19 +279,23 @@ mod tests {
         }
     }
 
+    fn policy(mappings: Vec<GroupMapping>) -> PolicyEngine {
+        PolicyEngine::new(mappings)
+    }
+
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     #[tokio::test]
     async fn user_in_group_not_in_room_is_force_joined() {
         let synapse = MockSynapse::default(); // members = []
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -313,13 +318,13 @@ mod tests {
             ..Default::default()
         };
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -341,13 +346,13 @@ mod tests {
             ..Default::default()
         };
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups: Vec<String> = vec![]; // not in group
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -369,13 +374,13 @@ mod tests {
             ..Default::default()
         };
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups: Vec<String> = vec![];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -397,13 +402,13 @@ mod tests {
             ..Default::default()
         };
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -426,16 +431,16 @@ mod tests {
         };
         let audit = audit().await;
         // Two mappings — first fails, second should still run.
-        let mappings = vec![
+        let policy = policy(vec![
             mapping("staff", "!room1:test.com"),
             mapping("staff", "!room2:test.com"),
-        ];
+        ]);
         let groups = vec!["staff".to_string()];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -458,13 +463,13 @@ mod tests {
             ..Default::default()
         };
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups: Vec<String> = vec![];
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,
@@ -483,11 +488,12 @@ mod tests {
     async fn no_mappings_returns_ok_with_no_warnings() {
         let synapse = MockSynapse::default();
         let audit = audit().await;
+        let policy = PolicyEngine::default();
 
         let outcome = reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &[],
+            &policy,
             &["staff".to_string()],
             &synapse,
             &audit,
@@ -506,10 +512,10 @@ mod tests {
     #[tokio::test]
     async fn preview_user_in_group_not_in_room_lists_join() {
         let synapse = MockSynapse::default(); // members = []
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
-        let preview = preview_membership("@alice:test.com", &mappings, &groups, &synapse, false)
+        let preview = preview_membership("@alice:test.com", &policy, &groups, &synapse, false)
             .await
             .unwrap();
 
@@ -526,10 +532,10 @@ mod tests {
             members: vec!["@alice:test.com".to_string()],
             ..Default::default()
         };
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
-        let preview = preview_membership("@alice:test.com", &mappings, &groups, &synapse, false)
+        let preview = preview_membership("@alice:test.com", &policy, &groups, &synapse, false)
             .await
             .unwrap();
 
@@ -544,10 +550,10 @@ mod tests {
             members: vec!["@alice:test.com".to_string()],
             ..Default::default()
         };
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups: Vec<String> = vec![]; // not in group
 
-        let preview = preview_membership("@alice:test.com", &mappings, &groups, &synapse, true)
+        let preview = preview_membership("@alice:test.com", &policy, &groups, &synapse, true)
             .await
             .unwrap();
 
@@ -561,10 +567,10 @@ mod tests {
             members: vec!["@alice:test.com".to_string()],
             ..Default::default()
         };
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups: Vec<String> = vec![];
 
-        let preview = preview_membership("@alice:test.com", &mappings, &groups, &synapse, false)
+        let preview = preview_membership("@alice:test.com", &policy, &groups, &synapse, false)
             .await
             .unwrap();
 
@@ -579,10 +585,10 @@ mod tests {
             fail_get_members: true,
             ..Default::default()
         };
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
-        let preview = preview_membership("@alice:test.com", &mappings, &groups, &synapse, false)
+        let preview = preview_membership("@alice:test.com", &policy, &groups, &synapse, false)
             .await
             .unwrap();
 
@@ -593,10 +599,11 @@ mod tests {
     #[tokio::test]
     async fn preview_no_mappings_returns_empty() {
         let synapse = MockSynapse::default();
+        let policy = PolicyEngine::default();
 
         let preview = preview_membership(
             "@alice:test.com",
-            &[],
+            &policy,
             &["staff".to_string()],
             &synapse,
             false,
@@ -614,13 +621,13 @@ mod tests {
     async fn reconcile_writes_audit_logs() {
         let synapse = MockSynapse::default(); // members = []
         let audit = audit().await;
-        let mappings = vec![mapping("staff", "!room1:test.com")];
+        let policy = policy(vec![mapping("staff", "!room1:test.com")]);
         let groups = vec!["staff".to_string()];
 
         reconcile_membership(
             "kc-1",
             "@alice:test.com",
-            &mappings,
+            &policy,
             &groups,
             &synapse,
             &audit,

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ use crate::{
     auth::oidc::OidcClient,
     clients::{KeycloakApi, MasApi, SynapseApi},
     config::Config,
+    models::policy::PolicyEngine,
     services::{AuditService, UserService},
 };
 
@@ -23,6 +24,8 @@ pub struct AppState {
     pub synapse: Option<Arc<dyn SynapseApi>>,
     pub users: Arc<UserService>,
     pub audit: Arc<AuditService>,
+    /// Group → room membership policy built from `GROUP_MAPPINGS` config at startup.
+    pub policy: Arc<PolicyEngine>,
     /// Encryption key for `PrivateCookieJar`.
     pub cookie_key: Key,
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -14,6 +14,7 @@ use crate::{
     models::{
         keycloak::{KeycloakGroup, KeycloakRole, KeycloakUser},
         mas::{MasSession, MasUser},
+        policy::PolicyEngine,
         synapse::{SynapseDevice, SynapseUser},
     },
     services::{AuditService, UserService},
@@ -369,6 +370,7 @@ pub async fn build_test_state_full(
         synapse: None,
         users,
         audit,
+        policy: Arc::new(PolicyEngine::default()),
         cookie_key,
     }
 }
@@ -394,9 +396,10 @@ pub async fn build_test_state_with_synapse(
 ) -> AppState {
     let mut state = build_test_state_full(keycloak, MockMas::default(), "secret", None).await;
     let mut config = (*state.config).clone();
-    config.group_mappings = group_mappings;
+    config.group_mappings = group_mappings.clone();
     config.reconcile_remove_from_rooms = reconcile_remove_from_rooms;
     state.config = Arc::new(config);
+    state.policy = Arc::new(PolicyEngine::new(group_mappings));
     state.synapse = Some(Arc::new(synapse));
     state
 }


### PR DESCRIPTION
## Summary

- Adds `PolicyEngine` to `src/models/policy.rs` with `required_rooms_for`, `mappings_for`, `all_mappings`, and `is_empty` query methods
- `AppState` gains a `policy: Arc<PolicyEngine>` field, built once at startup from `config.group_mappings`
- `reconcile_membership` and `preview_membership` now accept `policy: &PolicyEngine` instead of a raw `&[GroupMapping]` slice
- All handler call sites updated to pass `&state.policy`
- 8 new `PolicyEngine` unit tests

## Design

`Config.group_mappings` remains the raw deserialized source. `PolicyEngine` is the query-layer wrapper constructed once in `build_state()` — handlers and workflows never iterate the raw vec directly.

## Test plan

- [x] 214 tests pass (8 new)
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #42