### PR TITLE
feat(offboard): add offboard workflow with lifecycle primitives

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod delete;
 pub mod devices;
 pub mod disable;
 pub mod invite;
+pub mod offboard;
 pub mod reconcile;
 pub mod sessions;
 pub mod users;

--- a/src/handlers/offboard.rs
+++ b/src/handlers/offboard.rs
@@ -1,0 +1,229 @@
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Redirect},
+    Form,
+};
+use serde::Deserialize;
+
+use crate::{
+    auth::{csrf::validate, session::AuthenticatedAdmin},
+    error::AppError,
+    services::offboard_user::offboard_user,
+    state::AppState,
+    utils::pct_encode,
+};
+
+#[derive(Deserialize)]
+pub struct OffboardForm {
+    pub _csrf: String,
+}
+
+/// POST /users/{id}/offboard
+///
+/// Revokes all auth sessions, forces identity logout, disables the identity
+/// account, kicks from all mapped rooms, and deactivates the auth account.
+pub async fn offboard(
+    AuthenticatedAdmin(admin): AuthenticatedAdmin,
+    State(state): State<AppState>,
+    Path(keycloak_id): Path<String>,
+    Form(form): Form<OffboardForm>,
+) -> Result<impl IntoResponse, AppError> {
+    validate(&admin.csrf_token, &form._csrf)?;
+
+    let outcome = offboard_user(
+        &keycloak_id,
+        state.keycloak.as_ref(),
+        state.mas.as_ref(),
+        state.synapse.as_deref(),
+        &state.config.group_mappings,
+        &state.audit,
+        &admin.subject,
+        &admin.username,
+        &state.config.homeserver_domain,
+    )
+    .await?;
+
+    let redirect = if outcome.has_warnings() {
+        let mut warning = pct_encode(&outcome.warning_summary());
+        if warning.len() > 400 {
+            warning.truncate(400);
+            warning.push_str("%E2%80%A6");
+        }
+        format!("/users/{keycloak_id}?warning={warning}")
+    } else {
+        let notice = pct_encode("User offboarded successfully");
+        format!("/users/{keycloak_id}?notice={notice}")
+    };
+
+    Ok(Redirect::to(&redirect))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use crate::{
+        models::{keycloak::KeycloakUser, mas::MasUser},
+        test_helpers::{
+            build_test_state_full, make_auth_cookie, mutations_router, MockKeycloak, MockMas,
+            TEST_CSRF,
+        },
+    };
+
+    fn test_kc_user() -> KeycloakUser {
+        KeycloakUser {
+            id: "kc-123".to_string(),
+            username: "testuser".to_string(),
+            email: Some("test@example.com".to_string()),
+            first_name: None,
+            last_name: None,
+            enabled: true,
+            email_verified: true,
+            created_timestamp: None,
+            required_actions: vec![],
+        }
+    }
+
+    fn test_mas_user() -> MasUser {
+        MasUser {
+            id: "mas-456".to_string(),
+            username: "testuser".to_string(),
+            deactivated_at: None,
+        }
+    }
+
+    async fn post_offboard(
+        state: crate::state::AppState,
+        user_id: &str,
+        csrf: &str,
+        auth_cookie: Option<&str>,
+    ) -> axum::response::Response {
+        let body = format!("_csrf={csrf}");
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/users/{user_id}/offboard"))
+            .header("content-type", "application/x-www-form-urlencoded");
+        if let Some(cookie) = auth_cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        mutations_router(state)
+            .oneshot(builder.body(Body::from(body)).unwrap())
+            .await
+            .unwrap()
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn offboard_success_redirects_to_user_page() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas {
+                user: Some(test_mas_user()),
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_offboard(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.starts_with("/users/kc-123"));
+    }
+
+    #[tokio::test]
+    async fn offboard_unauthenticated_redirects_to_login() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let resp = post_offboard(state, "kc-123", TEST_CSRF, None).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(resp.headers().get("location").unwrap(), "/auth/login");
+    }
+
+    #[tokio::test]
+    async fn offboard_invalid_csrf_returns_400() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_offboard(state, "kc-123", "wrong-csrf", Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn offboard_user_not_found_returns_404() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_offboard(state, "nonexistent", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn offboard_upstream_failure_returns_502() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                fail_disable: true,
+                ..Default::default()
+            },
+            MockMas::default(),
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_offboard(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn offboard_writes_audit_logs() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                ..Default::default()
+            },
+            MockMas {
+                user: Some(test_mas_user()),
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let audit = std::sync::Arc::clone(&state.audit);
+        let cookie = make_auth_cookie(TEST_CSRF);
+        post_offboard(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        let logs = audit.for_user("kc-123", 10).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"disable_identity_account_on_offboard"));
+        assert!(actions.contains(&"deactivate_auth_account_on_offboard"));
+        assert!(logs.iter().all(|l| l.result == "success"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use axum_extra::extract::cookie::Key;
 use sha2::{Digest, Sha512};
 use tower_http::{services::ServeDir, timeout::TimeoutLayer};
 
-use clients::{IdentityProviderApi, KeycloakClient, MasClient, SynapseClient};
+use clients::{IdentityProviderApi, KeycloakClient, MasClient, RoomManagementApi, SynapseClient};
 use config::Config;
 use models::policy::PolicyEngine;
 use services::{AuditService, UserService};
@@ -116,6 +116,7 @@ pub fn build_router(state: AppState) -> Router {
             post(handlers::delete::delete_user_handler),
         )
         .route("/users/{id}/disable", post(handlers::disable::disable))
+        .route("/users/{id}/offboard", post(handlers::offboard::offboard))
         .route(
             "/users/{id}/reconcile",
             post(handlers::reconcile::reconcile),

--- a/src/services/lifecycle_steps.rs
+++ b/src/services/lifecycle_steps.rs
@@ -1,0 +1,889 @@
+//! Shared composable primitives for lifecycle workflows.
+//!
+//! Each function represents a single step that can be combined by higher-level
+//! workflows like `disable_user` and `offboard_user`. Functions take a
+//! `context` parameter (e.g. `"disable"`, `"offboard"`) used to construct
+//! audit action names like `revoke_auth_session_on_{context}`.
+
+use serde_json::json;
+
+use crate::{
+    clients::{KeycloakApi, MasApi, SynapseApi},
+    error::AppError,
+    models::{audit::AuditResult, group_mapping::GroupMapping, workflow::WorkflowOutcome},
+    services::AuditService,
+};
+
+/// Revoke all active auth (MAS) sessions for a user.
+///
+/// Non-fatal: if user lookup or session listing fails, a warning is logged and
+/// an empty outcome is returned. Per-session failures add warnings but do not
+/// abort the workflow.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn revoke_auth_sessions(
+    context: &str,
+    keycloak_id: &str,
+    username: &str,
+    matrix_user_id: &str,
+    mas: &dyn MasApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+) -> WorkflowOutcome {
+    let mut outcome = WorkflowOutcome::ok();
+
+    let auth_user = match mas.get_user_by_username(username).await {
+        Ok(Some(u)) => u,
+        Ok(None) => return outcome,
+        Err(e) => {
+            tracing::warn!(error = %e, "Auth user lookup failed during {context}; skipping session revocation");
+            outcome.add_warning(format!("Auth user lookup failed: {e}"));
+            return outcome;
+        }
+    };
+
+    let sessions = match mas.list_sessions(&auth_user.id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "Auth session list failed during {context}; skipping session revocation");
+            outcome.add_warning(format!("Auth session list failed: {e}"));
+            return outcome;
+        }
+    };
+
+    let action = format!("revoke_auth_session_on_{context}");
+
+    for session in sessions.iter().filter(|s| s.finished_at.is_none()) {
+        let result = mas.finish_session(&session.id, &session.session_type).await;
+        let audit_result = if result.is_ok() {
+            AuditResult::Success
+        } else {
+            AuditResult::Failure
+        };
+
+        let _ = audit
+            .log(
+                admin_subject,
+                admin_username,
+                Some(keycloak_id),
+                Some(matrix_user_id),
+                &action,
+                audit_result,
+                json!({
+                    "session_id": session.id,
+                    "session_type": session.session_type,
+                }),
+            )
+            .await;
+
+        if let Err(ref e) = result {
+            tracing::warn!(
+                session_id = %session.id,
+                error = %e,
+                "Failed to revoke auth session during {context}"
+            );
+            outcome.add_warning(format!(
+                "Session {} ({}) could not be revoked: {}",
+                session.id, session.session_type, e
+            ));
+        }
+    }
+
+    outcome
+}
+
+/// Force-logout a user from Keycloak.
+///
+/// Non-fatal: failure adds a warning to the outcome rather than returning an error.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn force_identity_logout(
+    context: &str,
+    keycloak_id: &str,
+    matrix_user_id: &str,
+    keycloak: &dyn KeycloakApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+) -> WorkflowOutcome {
+    let mut outcome = WorkflowOutcome::ok();
+    let action = format!("force_identity_logout_on_{context}");
+
+    let result = keycloak.logout_user(keycloak_id).await;
+    let audit_result = if result.is_ok() {
+        AuditResult::Success
+    } else {
+        AuditResult::Failure
+    };
+
+    let _ = audit
+        .log(
+            admin_subject,
+            admin_username,
+            Some(keycloak_id),
+            Some(matrix_user_id),
+            &action,
+            audit_result,
+            json!({ "keycloak_user_id": keycloak_id }),
+        )
+        .await;
+
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "Force identity logout failed during {context}");
+        outcome.add_warning(format!("Identity logout failed: {e}"));
+    }
+
+    outcome
+}
+
+/// Disable a user account in Keycloak.
+///
+/// Fatal: returns `Err` on failure (after audit logging the failure).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn disable_identity_account(
+    context: &str,
+    keycloak_id: &str,
+    username: &str,
+    matrix_user_id: &str,
+    keycloak: &dyn KeycloakApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+) -> Result<(), AppError> {
+    let action = format!("disable_identity_account_on_{context}");
+
+    let result = keycloak.disable_user(keycloak_id).await;
+    let audit_result = if result.is_ok() {
+        AuditResult::Success
+    } else {
+        AuditResult::Failure
+    };
+
+    let _ = audit
+        .log(
+            admin_subject,
+            admin_username,
+            Some(keycloak_id),
+            Some(matrix_user_id),
+            &action,
+            audit_result,
+            json!({
+                "keycloak_user_id": keycloak_id,
+                "username": username,
+            }),
+        )
+        .await;
+
+    result
+}
+
+/// Deactivate a user account in MAS.
+///
+/// Fatal: returns `Err` on failure (after audit logging the failure).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn deactivate_auth_account(
+    context: &str,
+    keycloak_id: &str,
+    auth_user_id: &str,
+    username: &str,
+    matrix_user_id: &str,
+    mas: &dyn MasApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+) -> Result<(), AppError> {
+    let action = format!("deactivate_auth_account_on_{context}");
+
+    let result = mas.delete_user(auth_user_id).await;
+    let audit_result = if result.is_ok() {
+        AuditResult::Success
+    } else {
+        AuditResult::Failure
+    };
+
+    let _ = audit
+        .log(
+            admin_subject,
+            admin_username,
+            Some(keycloak_id),
+            Some(matrix_user_id),
+            &action,
+            audit_result,
+            json!({
+                "auth_user_id": auth_user_id,
+                "username": username,
+            }),
+        )
+        .await;
+
+    result
+}
+
+/// Kick a user from all rooms mapped via group policy.
+///
+/// Non-fatal: per-room failures add warnings but do not abort. Unlike
+/// `reconcile_membership`, this kicks from ALL mapped rooms unconditionally,
+/// regardless of the user's current group membership.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn kick_from_all_mapped_rooms(
+    context: &str,
+    keycloak_id: &str,
+    matrix_user_id: &str,
+    group_mappings: &[GroupMapping],
+    synapse: &dyn SynapseApi,
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+) -> WorkflowOutcome {
+    let mut outcome = WorkflowOutcome::ok();
+    let action = format!("kick_room_on_{context}");
+
+    for mapping in group_mappings {
+        let members = match synapse
+            .get_joined_room_members(&mapping.matrix_room_id)
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                outcome.add_warning(format!(
+                    "Could not fetch members of {}: {}",
+                    mapping.matrix_room_id, e
+                ));
+                continue;
+            }
+        };
+
+        if !members.contains(&matrix_user_id.to_string()) {
+            continue;
+        }
+
+        let result = synapse
+            .kick_user_from_room(matrix_user_id, &mapping.matrix_room_id, "Offboarded")
+            .await;
+        let audit_result = if result.is_ok() {
+            AuditResult::Success
+        } else {
+            AuditResult::Failure
+        };
+
+        let _ = audit
+            .log(
+                admin_subject,
+                admin_username,
+                Some(keycloak_id),
+                Some(matrix_user_id),
+                &action,
+                audit_result,
+                json!({
+                    "room_id": mapping.matrix_room_id,
+                    "keycloak_group": mapping.keycloak_group,
+                }),
+            )
+            .await;
+
+        if let Err(e) = result {
+            outcome.add_warning(format!(
+                "Could not kick {} from {}: {}",
+                matrix_user_id, mapping.matrix_room_id, e
+            ));
+        }
+    }
+
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    use super::*;
+    use crate::{
+        models::{
+            keycloak::{KeycloakGroup, KeycloakRole, KeycloakUser},
+            mas::{MasSession, MasUser},
+            synapse::{SynapseDevice, SynapseUser},
+        },
+        services::AuditService,
+    };
+
+    // ── Test helpers ───────────────────────────────────────────────────────────
+
+    async fn audit_svc() -> AuditService {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        AuditService::new(pool)
+    }
+
+    fn active_session(id: &str) -> MasSession {
+        MasSession {
+            id: id.to_string(),
+            session_type: "compat".to_string(),
+            created_at: None,
+            last_active_at: None,
+            user_agent: None,
+            ip_address: None,
+            finished_at: None,
+        }
+    }
+
+    fn finished_session(id: &str) -> MasSession {
+        MasSession {
+            id: id.to_string(),
+            session_type: "compat".to_string(),
+            created_at: None,
+            last_active_at: None,
+            user_agent: None,
+            ip_address: None,
+            finished_at: Some("2026-01-01T00:00:00Z".to_string()),
+        }
+    }
+
+    fn mapping(group: &str, room: &str) -> GroupMapping {
+        GroupMapping {
+            keycloak_group: group.to_string(),
+            matrix_room_id: room.to_string(),
+        }
+    }
+
+    // ── Mock KeycloakApi ───────────────────────────────────────────────────────
+
+    struct MockKeycloak {
+        fail_logout: bool,
+        fail_disable: bool,
+    }
+
+    #[async_trait]
+    impl KeycloakApi for MockKeycloak {
+        async fn search_users(
+            &self,
+            _: &str,
+            _: u32,
+            _: u32,
+        ) -> Result<Vec<KeycloakUser>, AppError> {
+            unimplemented!()
+        }
+        async fn count_users(&self, _: &str) -> Result<u32, AppError> {
+            unimplemented!()
+        }
+        async fn get_user(&self, _: &str) -> Result<KeycloakUser, AppError> {
+            unimplemented!()
+        }
+        async fn get_user_by_email(&self, _: &str) -> Result<Option<KeycloakUser>, AppError> {
+            unimplemented!()
+        }
+        async fn get_user_groups(&self, _: &str) -> Result<Vec<KeycloakGroup>, AppError> {
+            unimplemented!()
+        }
+        async fn get_user_roles(&self, _: &str) -> Result<Vec<KeycloakRole>, AppError> {
+            unimplemented!()
+        }
+        async fn logout_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_logout {
+                Err(AppError::Upstream {
+                    service: "keycloak".into(),
+                    message: "mock logout failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn create_user(&self, _: &str, _: &str) -> Result<String, AppError> {
+            unimplemented!()
+        }
+        async fn send_invite_email(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn disable_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_disable {
+                Err(AppError::Upstream {
+                    service: "keycloak".into(),
+                    message: "mock disable failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    // ── Mock MasApi ────────────────────────────────────────────────────────────
+
+    struct MockMas {
+        user: Option<MasUser>,
+        sessions: Vec<MasSession>,
+        fail_finish: bool,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl MasApi for MockMas {
+        async fn get_user_by_username(&self, _: &str) -> Result<Option<MasUser>, AppError> {
+            Ok(self.user.clone())
+        }
+        async fn list_sessions(&self, _: &str) -> Result<Vec<MasSession>, AppError> {
+            Ok(self.sessions.clone())
+        }
+        async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
+            if self.fail_finish {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock finish failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_delete {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock delete failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+    }
+
+    fn mas_user() -> MasUser {
+        MasUser {
+            id: "mas-001".to_string(),
+            username: "alice".to_string(),
+            deactivated_at: None,
+        }
+    }
+
+    // ── Mock SynapseApi ────────────────────────────────────────────────────────
+
+    #[derive(Default)]
+    struct MockSynapse {
+        members: Vec<String>,
+        fail_get_members: bool,
+        fail_kick: bool,
+    }
+
+    #[async_trait]
+    impl SynapseApi for MockSynapse {
+        async fn get_user(&self, _: &str) -> Result<Option<SynapseUser>, AppError> {
+            unimplemented!()
+        }
+        async fn list_devices(&self, _: &str) -> Result<Vec<SynapseDevice>, AppError> {
+            unimplemented!()
+        }
+        async fn delete_device(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn get_joined_room_members(&self, _: &str) -> Result<Vec<String>, AppError> {
+            if self.fail_get_members {
+                Err(AppError::Upstream {
+                    service: "synapse".into(),
+                    message: "mock member fetch failure".into(),
+                })
+            } else {
+                Ok(self.members.clone())
+            }
+        }
+        async fn force_join_user(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn kick_user_from_room(&self, _: &str, _: &str, _: &str) -> Result<(), AppError> {
+            if self.fail_kick {
+                Err(AppError::Upstream {
+                    service: "synapse".into(),
+                    message: "mock kick failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    // ── revoke_auth_sessions ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn revoke_sessions_no_auth_user_returns_ok() {
+        let audit = audit_svc().await;
+        let mas = MockMas {
+            user: None,
+            sessions: vec![],
+            fail_finish: false,
+            fail_delete: false,
+        };
+
+        let outcome = revoke_auth_sessions(
+            "disable",
+            "kc-1",
+            "alice",
+            "@alice:example.com",
+            &mas,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(!outcome.has_warnings());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert!(logs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn revoke_sessions_finishes_active_skips_finished() {
+        let audit = audit_svc().await;
+        let mas = MockMas {
+            user: Some(mas_user()),
+            sessions: vec![
+                active_session("s1"),
+                active_session("s2"),
+                finished_session("s3"),
+            ],
+            fail_finish: false,
+            fail_delete: false,
+        };
+
+        let outcome = revoke_auth_sessions(
+            "disable",
+            "kc-1",
+            "alice",
+            "@alice:example.com",
+            &mas,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(!outcome.has_warnings());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 2);
+        assert!(logs
+            .iter()
+            .all(|l| l.action == "revoke_auth_session_on_disable"));
+        assert!(logs.iter().all(|l| l.result == "success"));
+    }
+
+    #[tokio::test]
+    async fn revoke_sessions_failure_is_non_fatal_warning() {
+        let audit = audit_svc().await;
+        let mas = MockMas {
+            user: Some(mas_user()),
+            sessions: vec![active_session("s1")],
+            fail_finish: true,
+            fail_delete: false,
+        };
+
+        let outcome = revoke_auth_sessions(
+            "offboard",
+            "kc-1",
+            "alice",
+            "@alice:example.com",
+            &mas,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("s1"));
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "revoke_auth_session_on_offboard");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    // ── force_identity_logout ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn force_logout_success() {
+        let audit = audit_svc().await;
+        let keycloak = MockKeycloak {
+            fail_logout: false,
+            fail_disable: false,
+        };
+
+        let outcome = force_identity_logout(
+            "disable",
+            "kc-1",
+            "@alice:example.com",
+            &keycloak,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(!outcome.has_warnings());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "force_identity_logout_on_disable");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn force_logout_failure_is_warning() {
+        let audit = audit_svc().await;
+        let keycloak = MockKeycloak {
+            fail_logout: true,
+            fail_disable: false,
+        };
+
+        let outcome = force_identity_logout(
+            "offboard",
+            "kc-1",
+            "@alice:example.com",
+            &keycloak,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("Identity logout failed"));
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "force_identity_logout_on_offboard");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    // ── disable_identity_account ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn disable_account_success() {
+        let audit = audit_svc().await;
+        let keycloak = MockKeycloak {
+            fail_logout: false,
+            fail_disable: false,
+        };
+
+        let result = disable_identity_account(
+            "disable",
+            "kc-1",
+            "alice",
+            "@alice:example.com",
+            &keycloak,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "disable_identity_account_on_disable");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn disable_account_failure_returns_error() {
+        let audit = audit_svc().await;
+        let keycloak = MockKeycloak {
+            fail_logout: false,
+            fail_disable: true,
+        };
+
+        let result = disable_identity_account(
+            "offboard",
+            "kc-1",
+            "alice",
+            "@alice:example.com",
+            &keycloak,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "disable_identity_account_on_offboard");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    // ── deactivate_auth_account ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn deactivate_account_success() {
+        let audit = audit_svc().await;
+        let mas = MockMas {
+            user: None,
+            sessions: vec![],
+            fail_finish: false,
+            fail_delete: false,
+        };
+
+        let result = deactivate_auth_account(
+            "offboard",
+            "kc-1",
+            "mas-001",
+            "alice",
+            "@alice:example.com",
+            &mas,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "deactivate_auth_account_on_offboard");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn deactivate_account_failure_returns_error() {
+        let audit = audit_svc().await;
+        let mas = MockMas {
+            user: None,
+            sessions: vec![],
+            fail_finish: false,
+            fail_delete: true,
+        };
+
+        let result = deactivate_auth_account(
+            "offboard",
+            "kc-1",
+            "mas-001",
+            "alice",
+            "@alice:example.com",
+            &mas,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "deactivate_auth_account_on_offboard");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    // ── kick_from_all_mapped_rooms ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn kick_present_user_from_room() {
+        let audit = audit_svc().await;
+        let synapse = MockSynapse {
+            members: vec!["@alice:example.com".to_string()],
+            ..Default::default()
+        };
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = kick_from_all_mapped_rooms(
+            "offboard",
+            "kc-1",
+            "@alice:example.com",
+            &mappings,
+            &synapse,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(!outcome.has_warnings());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "kick_room_on_offboard");
+        assert_eq!(logs[0].result, "success");
+    }
+
+    #[tokio::test]
+    async fn kick_skips_absent_user() {
+        let audit = audit_svc().await;
+        let synapse = MockSynapse {
+            members: vec!["@bob:example.com".to_string()],
+            ..Default::default()
+        };
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = kick_from_all_mapped_rooms(
+            "offboard",
+            "kc-1",
+            "@alice:example.com",
+            &mappings,
+            &synapse,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(!outcome.has_warnings());
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert!(logs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn kick_failure_is_non_fatal_warning() {
+        let audit = audit_svc().await;
+        let synapse = MockSynapse {
+            members: vec!["@alice:example.com".to_string()],
+            fail_kick: true,
+            ..Default::default()
+        };
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = kick_from_all_mapped_rooms(
+            "offboard",
+            "kc-1",
+            "@alice:example.com",
+            &mappings,
+            &synapse,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("Could not kick"));
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].action, "kick_room_on_offboard");
+        assert_eq!(logs[0].result, "failure");
+    }
+
+    #[tokio::test]
+    async fn kick_member_fetch_failure_is_warning() {
+        let audit = audit_svc().await;
+        let synapse = MockSynapse {
+            fail_get_members: true,
+            ..Default::default()
+        };
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = kick_from_all_mapped_rooms(
+            "offboard",
+            "kc-1",
+            "@alice:example.com",
+            &mappings,
+            &synapse,
+            &audit,
+            "sub",
+            "admin",
+        )
+        .await;
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("Could not fetch members"));
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert!(logs.is_empty());
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,6 +3,8 @@ pub mod delete_user;
 pub mod disable_user;
 pub mod identity_mapper;
 pub mod invite_user;
+pub mod lifecycle_steps;
+pub mod offboard_user;
 pub mod reconcile_membership;
 pub mod user_service;
 

--- a/src/services/offboard_user.rs
+++ b/src/services/offboard_user.rs
@@ -1,0 +1,629 @@
+//! Offboard-user workflow: fully removes a user from all systems.
+//!
+//! Composes lifecycle primitives into a complete offboarding sequence:
+//! revoke sessions -> force logout -> disable account -> kick rooms ->
+//! deactivate auth account. Non-fatal steps collect warnings;
+//! fatal steps abort on failure.
+
+use crate::{
+    clients::{KeycloakApi, MasApi, SynapseApi},
+    error::AppError,
+    models::{group_mapping::GroupMapping, workflow::WorkflowOutcome},
+    services::{lifecycle_steps, AuditService},
+};
+
+/// Offboard a user: revoke sessions, force logout, disable identity,
+/// kick from mapped rooms, and deactivate auth account.
+///
+/// Steps 1-2 (session revocation, identity logout) are non-fatal.
+/// Step 3 (identity disable) is fatal — failure aborts remaining steps.
+/// Step 4 (room kicks) is non-fatal; skipped with warning if no Synapse connector.
+/// Step 5 (auth deactivation) is fatal if the auth user exists; if the auth user
+/// lookup fails, it is non-fatal (logged as warning and skipped).
+#[allow(clippy::too_many_arguments)]
+pub async fn offboard_user(
+    keycloak_id: &str,
+    keycloak: &dyn KeycloakApi,
+    mas: &dyn MasApi,
+    synapse: Option<&dyn SynapseApi>,
+    group_mappings: &[GroupMapping],
+    audit: &AuditService,
+    admin_subject: &str,
+    admin_username: &str,
+    homeserver_domain: &str,
+) -> Result<WorkflowOutcome, AppError> {
+    let kc_user = keycloak.get_user(keycloak_id).await?;
+    let username = &kc_user.username;
+    let matrix_user_id = format!("@{}:{}", username, homeserver_domain);
+
+    // 1. Revoke auth sessions (non-fatal)
+    let mut outcome = lifecycle_steps::revoke_auth_sessions(
+        "offboard",
+        keycloak_id,
+        username,
+        &matrix_user_id,
+        mas,
+        audit,
+        admin_subject,
+        admin_username,
+    )
+    .await;
+
+    // 2. Force identity logout (non-fatal)
+    let logout_outcome = lifecycle_steps::force_identity_logout(
+        "offboard",
+        keycloak_id,
+        &matrix_user_id,
+        keycloak,
+        audit,
+        admin_subject,
+        admin_username,
+    )
+    .await;
+    outcome.warnings.extend(logout_outcome.warnings);
+
+    // 3. Disable identity account (fatal)
+    lifecycle_steps::disable_identity_account(
+        "offboard",
+        keycloak_id,
+        username,
+        &matrix_user_id,
+        keycloak,
+        audit,
+        admin_subject,
+        admin_username,
+    )
+    .await?;
+
+    // 4. Kick from all mapped rooms (non-fatal; skip if no Synapse connector)
+    if let Some(synapse) = synapse {
+        let kick_outcome = lifecycle_steps::kick_from_all_mapped_rooms(
+            "offboard",
+            keycloak_id,
+            &matrix_user_id,
+            group_mappings,
+            synapse,
+            audit,
+            admin_subject,
+            admin_username,
+        )
+        .await;
+        outcome.warnings.extend(kick_outcome.warnings);
+    } else if !group_mappings.is_empty() {
+        outcome.add_warning(
+            "Matrix connector not configured; room membership was not cleaned up".to_string(),
+        );
+    }
+
+    // 5. Deactivate auth account (fatal if auth user exists)
+    let auth_user = match mas.get_user_by_username(username).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!(error = %e, "Auth user lookup failed during offboard deactivation");
+            outcome.add_warning(format!(
+                "Auth user lookup failed; skipping deactivation: {e}"
+            ));
+            None
+        }
+    };
+    if let Some(ref auth_user) = auth_user {
+        lifecycle_steps::deactivate_auth_account(
+            "offboard",
+            keycloak_id,
+            &auth_user.id,
+            username,
+            &matrix_user_id,
+            mas,
+            audit,
+            admin_subject,
+            admin_username,
+        )
+        .await?;
+    }
+
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    use super::*;
+    use crate::models::{
+        keycloak::{KeycloakGroup, KeycloakRole, KeycloakUser},
+        mas::{MasSession, MasUser},
+        synapse::{SynapseDevice, SynapseUser},
+    };
+
+    // ── Test helpers ───────────────────────────────────────────────────────────
+
+    fn kc_user(id: &str, username: &str) -> KeycloakUser {
+        KeycloakUser {
+            id: id.to_string(),
+            username: username.to_string(),
+            email: Some(format!("{username}@example.com")),
+            first_name: None,
+            last_name: None,
+            enabled: true,
+            email_verified: true,
+            created_timestamp: None,
+            required_actions: vec![],
+        }
+    }
+
+    fn mas_user() -> MasUser {
+        MasUser {
+            id: "mas-001".to_string(),
+            username: "alice".to_string(),
+            deactivated_at: None,
+        }
+    }
+
+    fn active_session(id: &str) -> MasSession {
+        MasSession {
+            id: id.to_string(),
+            session_type: "compat".to_string(),
+            created_at: None,
+            last_active_at: None,
+            user_agent: None,
+            ip_address: None,
+            finished_at: None,
+        }
+    }
+
+    fn mapping(group: &str, room: &str) -> GroupMapping {
+        GroupMapping {
+            keycloak_group: group.to_string(),
+            matrix_room_id: room.to_string(),
+        }
+    }
+
+    async fn audit_svc() -> AuditService {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        AuditService::new(pool)
+    }
+
+    // ── Mock KeycloakApi ───────────────────────────────────────────────────────
+
+    struct MockKc {
+        user: Option<KeycloakUser>,
+        fail_logout: bool,
+        fail_disable: bool,
+    }
+
+    #[async_trait]
+    impl KeycloakApi for MockKc {
+        async fn search_users(
+            &self,
+            _: &str,
+            _: u32,
+            _: u32,
+        ) -> Result<Vec<KeycloakUser>, AppError> {
+            unimplemented!()
+        }
+        async fn count_users(&self, _: &str) -> Result<u32, AppError> {
+            unimplemented!()
+        }
+        async fn get_user(&self, _: &str) -> Result<KeycloakUser, AppError> {
+            self.user
+                .clone()
+                .ok_or_else(|| AppError::NotFound("not found".into()))
+        }
+        async fn get_user_by_email(&self, _: &str) -> Result<Option<KeycloakUser>, AppError> {
+            unimplemented!()
+        }
+        async fn get_user_groups(&self, _: &str) -> Result<Vec<KeycloakGroup>, AppError> {
+            unimplemented!()
+        }
+        async fn get_user_roles(&self, _: &str) -> Result<Vec<KeycloakRole>, AppError> {
+            unimplemented!()
+        }
+        async fn logout_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_logout {
+                Err(AppError::Upstream {
+                    service: "keycloak".into(),
+                    message: "mock logout failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn create_user(&self, _: &str, _: &str) -> Result<String, AppError> {
+            unimplemented!()
+        }
+        async fn send_invite_email(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn disable_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_disable {
+                Err(AppError::Upstream {
+                    service: "keycloak".into(),
+                    message: "mock disable failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    // ── Mock MasApi ────────────────────────────────────────────────────────────
+
+    struct MockMs {
+        user: Option<MasUser>,
+        sessions: Vec<MasSession>,
+        fail_finish: bool,
+        fail_delete: bool,
+        fail_get_user: bool,
+    }
+
+    impl MockMs {
+        fn with_user_and_sessions(user: MasUser, sessions: Vec<MasSession>) -> Self {
+            Self {
+                user: Some(user),
+                sessions,
+                fail_finish: false,
+                fail_delete: false,
+                fail_get_user: false,
+            }
+        }
+
+        fn empty() -> Self {
+            Self {
+                user: None,
+                sessions: vec![],
+                fail_finish: false,
+                fail_delete: false,
+                fail_get_user: false,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MasApi for MockMs {
+        async fn get_user_by_username(&self, _: &str) -> Result<Option<MasUser>, AppError> {
+            if self.fail_get_user {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock get user failure".into(),
+                })
+            } else {
+                Ok(self.user.clone())
+            }
+        }
+        async fn list_sessions(&self, _: &str) -> Result<Vec<MasSession>, AppError> {
+            Ok(self.sessions.clone())
+        }
+        async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
+            if self.fail_finish {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock finish failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_delete {
+                Err(AppError::Upstream {
+                    service: "mas".into(),
+                    message: "mock delete failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+    }
+
+    // ── Mock SynapseApi ────────────────────────────────────────────────────────
+
+    struct MockSyn {
+        members: Vec<String>,
+        fail_kick: bool,
+    }
+
+    impl MockSyn {
+        fn with_members(members: Vec<String>) -> Self {
+            Self {
+                members,
+                fail_kick: false,
+            }
+        }
+
+        fn failing_kick(members: Vec<String>) -> Self {
+            Self {
+                members,
+                fail_kick: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SynapseApi for MockSyn {
+        async fn get_user(&self, _: &str) -> Result<Option<SynapseUser>, AppError> {
+            unimplemented!()
+        }
+        async fn list_devices(&self, _: &str) -> Result<Vec<SynapseDevice>, AppError> {
+            unimplemented!()
+        }
+        async fn delete_device(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn get_joined_room_members(&self, _: &str) -> Result<Vec<String>, AppError> {
+            Ok(self.members.clone())
+        }
+        async fn force_join_user(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unimplemented!()
+        }
+        async fn kick_user_from_room(&self, _: &str, _: &str, _: &str) -> Result<(), AppError> {
+            if self.fail_kick {
+                Err(AppError::Upstream {
+                    service: "synapse".into(),
+                    message: "mock kick failure".into(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    // ── offboard_user tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn offboard_happy_path() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs::with_user_and_sessions(mas_user(), vec![active_session("s1")]);
+        let syn = MockSyn::with_members(vec!["@alice:example.com".to_string()]);
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            Some(&syn),
+            &mappings,
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        assert!(!outcome.has_warnings());
+
+        let logs = audit.for_user("kc-1", 20).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"revoke_auth_session_on_offboard"));
+        assert!(actions.contains(&"force_identity_logout_on_offboard"));
+        assert!(actions.contains(&"disable_identity_account_on_offboard"));
+        assert!(actions.contains(&"kick_room_on_offboard"));
+        assert!(actions.contains(&"deactivate_auth_account_on_offboard"));
+        assert!(logs.iter().all(|l| l.result == "success"));
+    }
+
+    #[tokio::test]
+    async fn offboard_no_auth_user_still_disables() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs::empty();
+
+        let outcome = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            None,
+            &[],
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        assert!(!outcome.has_warnings());
+
+        let logs = audit.for_user("kc-1", 20).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"disable_identity_account_on_offboard"));
+        assert!(!actions.contains(&"revoke_auth_session_on_offboard"));
+        assert!(!actions.contains(&"deactivate_auth_account_on_offboard"));
+    }
+
+    #[tokio::test]
+    async fn offboard_no_matrix_connector_warns() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs::empty();
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            None,
+            &mappings,
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("Matrix connector not configured"));
+    }
+
+    #[tokio::test]
+    async fn offboard_partial_room_kick_failure_is_warning() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs::with_user_and_sessions(mas_user(), vec![]);
+        let syn = MockSyn::failing_kick(vec!["@alice:example.com".to_string()]);
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let outcome = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            Some(&syn),
+            &mappings,
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.has_warnings());
+        assert!(outcome.warnings[0].contains("Could not kick"));
+
+        let logs = audit.for_user("kc-1", 20).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"deactivate_auth_account_on_offboard"));
+    }
+
+    #[tokio::test]
+    async fn offboard_identity_disable_failure_aborts() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: true,
+        };
+        let mas = MockMs::with_user_and_sessions(mas_user(), vec![]);
+        let syn = MockSyn::with_members(vec!["@alice:example.com".to_string()]);
+        let mappings = vec![mapping("staff", "!room1:example.com")];
+
+        let result = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            Some(&syn),
+            &mappings,
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await;
+
+        assert!(result.is_err());
+
+        let logs = audit.for_user("kc-1", 20).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(!actions.contains(&"kick_room_on_offboard"));
+        assert!(!actions.contains(&"deactivate_auth_account_on_offboard"));
+        assert!(actions.contains(&"disable_identity_account_on_offboard"));
+    }
+
+    #[tokio::test]
+    async fn offboard_auth_deactivation_failure_returns_error() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs {
+            user: Some(mas_user()),
+            sessions: vec![],
+            fail_finish: false,
+            fail_delete: true,
+            fail_get_user: false,
+        };
+
+        let result = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            None,
+            &[],
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await;
+
+        assert!(result.is_err());
+
+        let logs = audit.for_user("kc-1", 20).await.unwrap();
+        let actions: Vec<&str> = logs.iter().map(|l| l.action.as_str()).collect();
+        assert!(actions.contains(&"disable_identity_account_on_offboard"));
+        let disable_log = logs
+            .iter()
+            .find(|l| l.action == "disable_identity_account_on_offboard")
+            .unwrap();
+        assert_eq!(disable_log.result, "success");
+    }
+
+    #[tokio::test]
+    async fn offboard_auth_lookup_failure_is_non_fatal() {
+        let audit = audit_svc().await;
+        let kc = MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_logout: false,
+            fail_disable: false,
+        };
+        let mas = MockMs {
+            user: None,
+            sessions: vec![],
+            fail_finish: false,
+            fail_delete: false,
+            fail_get_user: true,
+        };
+
+        let outcome = offboard_user(
+            "kc-1",
+            &kc,
+            &mas,
+            None,
+            &[],
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.has_warnings());
+        assert!(outcome
+            .warnings
+            .iter()
+            .any(|w| w.contains("Auth user lookup failed")));
+    }
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -8,7 +8,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 use crate::{
     auth::oidc::OidcClient,
     auth::session::AdminSession,
-    clients::{IdentityProviderApi, KeycloakApi, MasApi, SynapseApi},
+    clients::{IdentityProviderApi, KeycloakApi, MasApi, RoomManagementApi, SynapseApi},
     config::{Config, KeycloakConfig, MasConfig, OidcConfig},
     error::AppError,
     models::{
@@ -619,6 +619,10 @@ pub fn mutations_router(state: AppState) -> Router {
         .route(
             "/users/{id}/disable",
             post(crate::handlers::disable::disable),
+        )
+        .route(
+            "/users/{id}/offboard",
+            post(crate::handlers::offboard::offboard),
         )
         .route(
             "/users/{id}/reconcile",

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -58,6 +58,13 @@
     <button type="submit" class="btn btn-danger">Disable User</button>
   </form>
 
+  <!-- Offboard user -->
+  <form method="post" action="/users/{{ user.keycloak_id }}/offboard" style="margin-top:0.5rem"
+        onsubmit="return confirm('Offboard {{ user.username }}? This will revoke all sessions, disable the account, remove from all mapped rooms, and deactivate the auth account. This is difficult to reverse.')">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+    <button type="submit" class="btn btn-danger">Offboard User</button>
+  </form>
+
   <!-- Delete user -->
   <form method="post" action="/users/{{ user.keycloak_id }}/delete" style="margin-top:0.5rem"
         onsubmit="return confirm('Permanently delete {{ user.username }} from Keycloak and MAS? This cannot be undone.')">


### PR DESCRIPTION
## Summary
- Adds shared lifecycle step primitives (`lifecycle_steps.rs`) — composable building blocks for multi-step workflows like disable and offboard
- Adds `offboard_user` workflow composing: revoke sessions → force logout → disable account → kick from mapped rooms → deactivate auth account
- Adds `POST /users/{id}/offboard` handler with CSRF, audit logging, and redirect-based feedback
- Adds Offboard User button to user detail page

## Design decisions
- Uses `KeycloakApi`, `MasApi`, `SynapseApi` from main (compatible with `IdentityProviderApi`/`RoomManagementApi` abstractions from PRs #48-50)
- Lifecycle primitives take a `context` parameter for audit action names (`revoke_auth_session_on_offboard` vs `on_disable`)
- Fatal vs non-fatal step semantics: identity disable and auth deactivation abort on failure; session revocation, logout, and room kicks collect warnings
- Does NOT refactor `disable_user` to use primitives yet — that's a follow-up to keep this PR focused

## Test plan
- [x] 13 unit tests for lifecycle step primitives
- [x] 7 unit tests for offboard_user workflow (happy path, missing auth user, no Synapse, partial failures, abort scenarios)
- [x] 6 handler tests (success, unauth, bad CSRF, 404, 502, audit logs)
- [x] All 249 tests pass locally
- [ ] CI checks (fmt, clippy, test, coverage, CodeQL, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)