### PR TITLE
fix(e2e): add media_store_path to Synapse config

### DIFF
--- a/e2e/homeserver.yaml
+++ b/e2e/homeserver.yaml
@@ -18,6 +18,8 @@ signing_key_path: /data/e2e.test.signing.key
 
 log_config: /data/log.config
 
+media_store_path: /data/media_store
+
 suppress_key_server_warning: true
 report_stats: false
 macaroon_secret_key: "e2e-macaroon-secret-not-real"


### PR DESCRIPTION
## Summary

- Synapse fails to start with `PermissionError: [Errno 13] Permission denied: '/media_store'` because the default media store path is outside the writable volume
- Add `media_store_path: /data/media_store` to `homeserver.yaml` so media is stored inside the named volume

## Test plan

- [ ] `docker compose -f e2e/docker-compose.yml down -v && docker compose -f e2e/docker-compose.yml up -d` — Synapse starts successfully
- [ ] `curl http://localhost:8008/health` returns `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)