### PR TITLE
fix(e2e): run Synapse as root for volume permissions

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -94,6 +94,9 @@ services:
 
   synapse:
     image: matrixdotorg/synapse:v1.127.1
+    # Run as root so Synapse can write to the named volume (uid 991 can't).
+    # Fine for e2e — not for production.
+    user: "0:0"
     environment:
       SYNAPSE_CONFIG_DIR: /data
       SYNAPSE_CONFIG_PATH: /data/homeserver.yaml


### PR DESCRIPTION
## Summary

- Synapse image runs as uid 991 which can't write to the Docker named volume (owned by root)
- Add `user: "0:0"` to the Synapse service so it can create `media_store`, `homeserver.db`, etc.
- Safe for e2e only — not for production

## Test plan

- [ ] `docker compose -f e2e/docker-compose.yml down -v && docker compose -f e2e/docker-compose.yml up -d` — Synapse starts successfully
- [ ] `curl http://localhost:8008/health` returns `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)