### PR TITLE
fix(e2e): separate config and data volume mounts

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -94,17 +94,14 @@ services:
 
   synapse:
     image: matrixdotorg/synapse:v1.127.1
-    # Run as root so Synapse can write to the named volume (uid 991 can't).
-    # Fine for e2e — not for production.
-    user: "0:0"
     environment:
-      SYNAPSE_CONFIG_DIR: /data
-      SYNAPSE_CONFIG_PATH: /data/homeserver.yaml
+      SYNAPSE_CONFIG_DIR: /config
+      SYNAPSE_CONFIG_PATH: /config/homeserver.yaml
     volumes:
       - synapse-data:/data
-      - ./homeserver.yaml:/data/homeserver.yaml:ro
-      - ./synapse-log.config:/data/log.config:ro
-      - ./e2e.test.signing.key:/data/e2e.test.signing.key:ro
+      - ./homeserver.yaml:/config/homeserver.yaml:ro
+      - ./synapse-log.config:/config/log.config:ro
+      - ./e2e.test.signing.key:/config/e2e.test.signing.key:ro
     ports:
       - "8008:8008"
     depends_on:

--- a/e2e/homeserver.yaml
+++ b/e2e/homeserver.yaml
@@ -14,9 +14,9 @@ database:
   args:
     database: /data/homeserver.db
 
-signing_key_path: /data/e2e.test.signing.key
+signing_key_path: /config/e2e.test.signing.key
 
-log_config: /data/log.config
+log_config: /config/log.config
 
 media_store_path: /data/media_store
 


### PR DESCRIPTION
## Summary

- Bind-mounting `:ro` files into `/data/` alongside the named volume was making the mount point read-only, preventing Synapse from creating `media_store`, `homeserver.db`, etc.
- Move config files (`homeserver.yaml`, `log.config`, `signing.key`) to `/config/` directory
- `/data` is now purely the named volume — fully writable for Synapse runtime data
- Remove `user: "0:0"` workaround (no longer needed)
- Update `homeserver.yaml` paths for `signing_key_path` and `log_config` to `/config/`

## Test plan

- [ ] `docker compose -f e2e/docker-compose.yml down -v && docker compose -f e2e/docker-compose.yml up -d`
- [ ] Synapse starts and `curl http://localhost:8008/health` returns `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)