### PR TITLE
fix(e2e): use tmpfs for Synapse /data directory

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -97,12 +97,14 @@ services:
     environment:
       SYNAPSE_CONFIG_DIR: /config
       SYNAPSE_CONFIG_PATH: /config/homeserver.yaml
-    # No named volume — Synapse writes to its container filesystem.
-    # E2E data doesn't need to persist between restarts.
     volumes:
       - ./homeserver.yaml:/config/homeserver.yaml:ro
       - ./synapse-log.config:/config/log.config:ro
       - ./e2e.test.signing.key:/config/e2e.test.signing.key:ro
+    # In-memory writable filesystem for Synapse runtime data (db, media, pid).
+    # Avoids Docker volume permission issues on macOS. Ephemeral — fine for e2e.
+    tmpfs:
+      - /data
     ports:
       - "8008:8008"
     depends_on:


### PR DESCRIPTION
## Summary

- Without a volume mount, `/data` doesn't exist in the container and Synapse can't create it (permission denied at `/`)
- Add `tmpfs: [/data]` — writable in-memory filesystem, no permission issues
- Data is ephemeral (lost on container restart), which is fine for e2e tests

## Test plan

- [ ] `docker compose -f e2e/docker-compose.yml down -v && docker compose -f e2e/docker-compose.yml up -d`
- [ ] Synapse starts and `curl http://localhost:8008/health` returns `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)