### PR TITLE
fix(mas): rename deactivation contract

### DIFF
--- a/src/clients/mas.rs
+++ b/src/clients/mas.rs
@@ -27,7 +27,7 @@ pub trait AuthService: Send + Sync {
     async fn finish_session(&self, session_id: &str, session_type: &str) -> Result<(), AppError>;
     /// Deactivate a MAS user by their MAS ULID, revoking all sessions.
     /// Note: does not free the email address — see TODO in the implementation.
-    async fn delete_user(&self, mas_user_id: &str) -> Result<(), AppError>;
+    async fn deactivate_user(&self, mas_user_id: &str) -> Result<(), AppError>;
     /// Reactivate a previously deactivated MAS user by their MAS ULID.
     async fn reactivate_user(&self, mas_user_id: &str) -> Result<(), AppError>;
 }
@@ -236,7 +236,7 @@ impl AuthService for MasClient {
         Ok(())
     }
 
-    async fn delete_user(&self, mas_user_id: &str) -> Result<(), AppError> {
+    async fn deactivate_user(&self, mas_user_id: &str) -> Result<(), AppError> {
         // TODO: MAS does not expose a hard-delete endpoint via its admin REST API.
         // `POST /deactivate` locks the account and revokes all sessions, but the
         // user record (including their email address) remains in the MAS database.

--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -197,7 +197,7 @@ mod tests {
             },
             MockMas {
                 user: Some(test_mas_user()),
-                fail_delete_user: true,
+                fail_deactivate_user: true,
                 ..Default::default()
             },
             "secret",

--- a/src/services/delete_user.rs
+++ b/src/services/delete_user.rs
@@ -7,7 +7,7 @@ use crate::{
     services::AuditService,
 };
 
-/// Delete a user account from Keycloak and MAS.
+/// Delete a user account from Keycloak and deactivate it in MAS.
 ///
 /// Steps:
 ///   1. Fetch the Keycloak user to resolve the username and Matrix ID.
@@ -40,7 +40,7 @@ pub async fn delete_user(
         });
 
     if let Some(ref mas_user) = mas_user {
-        let mas_result = mas.delete_user(&mas_user.id).await;
+        let mas_result = mas.deactivate_user(&mas_user.id).await;
         let audit_result = if mas_result.is_ok() {
             AuditResult::Success
         } else {
@@ -218,7 +218,7 @@ mod tests {
     struct MockMs {
         user: Option<MasUser>,
         fail_lookup: bool,
-        fail_delete: bool,
+        fail_deactivate: bool,
     }
 
     #[async_trait]
@@ -242,11 +242,11 @@ mod tests {
         async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
-            if self.fail_delete {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_deactivate {
                 Err(AppError::Upstream {
                     service: "mas".into(),
-                    message: "mock delete failure".into(),
+                    message: "mock deactivate failure".into(),
                 })
             } else {
                 Ok(())
@@ -327,7 +327,7 @@ mod tests {
         });
         let mas = Arc::new(MockMs {
             user: Some(mas_user("alice")),
-            fail_delete: true,
+            fail_deactivate: true,
             ..Default::default()
         });
 

--- a/src/services/disable_user.rs
+++ b/src/services/disable_user.rs
@@ -212,7 +212,7 @@ mod tests {
                 Ok(())
             }
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {

--- a/src/services/invite_user.rs
+++ b/src/services/invite_user.rs
@@ -331,7 +331,7 @@ mod tests {
         async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {

--- a/src/services/lifecycle_steps.rs
+++ b/src/services/lifecycle_steps.rs
@@ -247,7 +247,7 @@ pub(crate) async fn deactivate_auth_account(
 ) -> Result<(), AppError> {
     let action = format!("deactivate_auth_account_on_{context}");
 
-    let result = mas.delete_user(auth_user_id).await;
+    let result = mas.deactivate_user(auth_user_id).await;
     let audit_result = if result.is_ok() {
         AuditResult::Success
     } else {
@@ -576,7 +576,7 @@ mod tests {
         sessions: Vec<MasSession>,
         session_warnings: Vec<String>,
         fail_finish: bool,
-        fail_delete: bool,
+        fail_deactivate: bool,
         fail_reactivate: bool,
     }
 
@@ -601,11 +601,11 @@ mod tests {
                 Ok(())
             }
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
-            if self.fail_delete {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_deactivate {
                 Err(AppError::Upstream {
                     service: "mas".into(),
-                    message: "mock delete failure".into(),
+                    message: "mock deactivate failure".into(),
                 })
             } else {
                 Ok(())
@@ -728,7 +728,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -761,7 +761,7 @@ mod tests {
             ],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -794,7 +794,7 @@ mod tests {
             sessions: vec![active_session("s1")],
             session_warnings: vec![],
             fail_finish: true,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -826,7 +826,7 @@ mod tests {
             sessions: vec![active_session("s1")],
             session_warnings: vec!["Failed to fetch compat sessions: timeout".to_string()],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -976,7 +976,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -1008,7 +1008,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: true,
+            fail_deactivate: true,
             fail_reactivate: false,
         };
 
@@ -1254,7 +1254,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -1284,7 +1284,7 @@ mod tests {
             sessions: vec![active_session("s1")],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -1342,7 +1342,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -1462,7 +1462,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: false,
         };
 
@@ -1494,7 +1494,7 @@ mod tests {
             sessions: vec![],
             session_warnings: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_reactivate: true,
         };
 

--- a/src/services/offboard_user.rs
+++ b/src/services/offboard_user.rs
@@ -276,7 +276,7 @@ mod tests {
         user: Option<MasUser>,
         sessions: Vec<MasSession>,
         fail_finish: bool,
-        fail_delete: bool,
+        fail_deactivate: bool,
         fail_get_user: bool,
     }
 
@@ -286,7 +286,7 @@ mod tests {
                 user: Some(user),
                 sessions,
                 fail_finish: false,
-                fail_delete: false,
+                fail_deactivate: false,
                 fail_get_user: false,
             }
         }
@@ -296,7 +296,7 @@ mod tests {
                 user: None,
                 sessions: vec![],
                 fail_finish: false,
-                fail_delete: false,
+                fail_deactivate: false,
                 fail_get_user: false,
             }
         }
@@ -330,11 +330,11 @@ mod tests {
                 Ok(())
             }
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
-            if self.fail_delete {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
+            if self.fail_deactivate {
                 Err(AppError::Upstream {
                     service: "mas".into(),
-                    message: "mock delete failure".into(),
+                    message: "mock deactivate failure".into(),
                 })
             } else {
                 Ok(())
@@ -609,7 +609,7 @@ mod tests {
             user: Some(mas_user()),
             sessions: vec![],
             fail_finish: false,
-            fail_delete: true,
+            fail_deactivate: true,
             fail_get_user: false,
         };
 
@@ -650,7 +650,7 @@ mod tests {
             user: None,
             sessions: vec![],
             fail_finish: false,
-            fail_delete: false,
+            fail_deactivate: false,
             fail_get_user: true,
         };
 

--- a/src/services/reactivate_user.rs
+++ b/src/services/reactivate_user.rs
@@ -216,7 +216,7 @@ mod tests {
         async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {

--- a/src/services/user_service.rs
+++ b/src/services/user_service.rs
@@ -278,7 +278,7 @@ mod tests {
         ) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
@@ -622,7 +622,7 @@ mod tests {
         async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {
@@ -648,7 +648,7 @@ mod tests {
         async fn finish_session(&self, _: &str, _: &str) -> Result<(), AppError> {
             Ok(())
         }
-        async fn delete_user(&self, _: &str) -> Result<(), AppError> {
+        async fn deactivate_user(&self, _: &str) -> Result<(), AppError> {
             Ok(())
         }
         async fn reactivate_user(&self, _: &str) -> Result<(), AppError> {
@@ -759,13 +759,13 @@ mod tests {
             sessions: vec![],
         };
         let _ = mas.finish_session("id", "compat").await;
-        let _ = mas.delete_user("id").await;
+        let _ = mas.deactivate_user("id").await;
         let _ = mas.reactivate_user("id").await;
 
         let ml = MasLookupFails;
         let _ = ml.list_sessions("id").await;
         let _ = ml.finish_session("id", "compat").await;
-        let _ = ml.delete_user("id").await;
+        let _ = ml.deactivate_user("id").await;
         let _ = ml.reactivate_user("id").await;
 
         let ms = MasSessionsFail {
@@ -776,7 +776,7 @@ mod tests {
             },
         };
         let _ = ms.finish_session("id", "compat").await;
-        let _ = ms.delete_user("id").await;
+        let _ = ms.deactivate_user("id").await;
         let _ = ms.reactivate_user("id").await;
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -306,8 +306,8 @@ pub struct MockMas {
     pub sessions: Vec<MasSession>,
     /// If true, `finish_session` returns an upstream error.
     pub fail_finish_session: bool,
-    /// If true, `delete_user` returns an upstream error.
-    pub fail_delete_user: bool,
+    /// If true, `deactivate_user` returns an upstream error.
+    pub fail_deactivate_user: bool,
     /// If true, `reactivate_user` returns an upstream error.
     pub fail_reactivate: bool,
     /// If true, `get_user_by_username` returns an upstream error.
@@ -345,11 +345,11 @@ impl AuthService for MockMas {
         }
     }
 
-    async fn delete_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
-        if self.fail_delete_user {
+    async fn deactivate_user(&self, _mas_user_id: &str) -> Result<(), AppError> {
+        if self.fail_deactivate_user {
             Err(AppError::Upstream {
                 service: "mas".into(),
-                message: "mock delete_user failure".into(),
+                message: "mock deactivate_user failure".into(),
             })
         } else {
             Ok(())


### PR DESCRIPTION
## Summary
- rename the MAS connector contract from delete_user to deactivate_user
- update delete/offboard lifecycle callers and test doubles to use the real MAS semantics
- keep the Keycloak delete path unchanged so the workflow now reads as MAS deactivation plus Keycloak deletion

Closes #55.

## Verification
- flox activate -- cargo fmt --check
- flox activate -- cargo clippy --all-targets -- -D warnings
- flox activate -- cargo test