### PR TITLE
fix(delete): surface partial workflow failures

### DIFF
--- a/src/handlers/delete.rs
+++ b/src/handlers/delete.rs
@@ -8,8 +8,9 @@ use serde::Deserialize;
 use crate::{
     auth::{csrf::validate, session::AuthenticatedAdmin},
     error::AppError,
-    services::delete_user::delete_user,
+    services::delete_user::{delete_user, DeleteUserResult},
     state::AppState,
+    utils::pct_encode,
 };
 
 #[derive(Deserialize)]
@@ -31,7 +32,7 @@ pub async fn delete_user_handler(
 ) -> Result<impl IntoResponse, AppError> {
     validate(&admin.csrf_token, &form._csrf)?;
 
-    delete_user(
+    let result = delete_user(
         &keycloak_id,
         state.keycloak.as_ref(),
         state.mas.as_ref(),
@@ -42,7 +43,30 @@ pub async fn delete_user_handler(
     )
     .await?;
 
-    Ok(Redirect::to("/users/search"))
+    let redirect = match result {
+        DeleteUserResult::Deleted(outcome) => {
+            if outcome.has_warnings() {
+                let mut warning = pct_encode(&outcome.warning_summary());
+                if warning.len() > 400 {
+                    warning.truncate(400);
+                    warning.push_str("%E2%80%A6");
+                }
+                format!("/users/search?warning={warning}")
+            } else {
+                "/users/search".to_string()
+            }
+        }
+        DeleteUserResult::PartialFailure(outcome) => {
+            let mut warning = pct_encode(&outcome.warning_summary());
+            if warning.len() > 400 {
+                warning.truncate(400);
+                warning.push_str("%E2%80%A6");
+            }
+            format!("/users/{keycloak_id}?warning={warning}")
+        }
+    };
+
+    Ok(Redirect::to(&redirect))
 }
 
 #[cfg(test)]
@@ -210,7 +234,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_keycloak_failure_returns_502() {
+    async fn delete_keycloak_failure_without_mas_account_returns_502() {
         let state = build_test_state_full(
             MockKeycloak {
                 users: vec![test_kc_user()],
@@ -228,7 +252,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_mas_lookup_failure_still_deletes_keycloak_user() {
+    async fn delete_keycloak_failure_after_mas_deactivation_redirects_with_warning() {
+        let state = build_test_state_full(
+            MockKeycloak {
+                users: vec![test_kc_user()],
+                fail_delete: true,
+                ..Default::default()
+            },
+            MockMas {
+                user: Some(test_mas_user()),
+                ..Default::default()
+            },
+            "secret",
+            None,
+        )
+        .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.starts_with("/users/kc-123?warning="));
+    }
+
+    #[tokio::test]
+    async fn delete_mas_lookup_failure_still_deletes_keycloak_user_with_warning() {
         let state = build_test_state_full(
             MockKeycloak {
                 users: vec![test_kc_user()],
@@ -245,7 +292,8 @@ mod tests {
         let cookie = make_auth_cookie(TEST_CSRF);
         let resp = post_delete(state, "kc-123", TEST_CSRF, Some(&cookie)).await;
         assert_eq!(resp.status(), StatusCode::SEE_OTHER);
-        assert_eq!(resp.headers().get("location").unwrap(), "/users/search");
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.starts_with("/users/search?warning="));
     }
 
     #[tokio::test]

--- a/src/handlers/users.rs
+++ b/src/handlers/users.rs
@@ -20,6 +20,7 @@ const PAGE_SIZE: u32 = 25;
 pub struct SearchParams {
     pub q: Option<String>,
     pub page: Option<u32>,
+    pub warning: Option<String>,
 }
 
 #[derive(Template)]
@@ -28,6 +29,7 @@ struct SearchTemplate {
     username: String,
     csrf_token: String,
     query: String,
+    warning: Option<String>,
     results: Vec<UnifiedUserSummary>,
     page: u32,
     total_pages: u32,
@@ -55,6 +57,7 @@ pub async fn search(
         username: admin.username,
         csrf_token: admin.csrf_token,
         query,
+        warning: params.warning,
         results,
         page,
         total_pages,
@@ -220,6 +223,28 @@ mod tests {
         let cookie = make_auth_cookie(TEST_CSRF);
         let resp = get_search(state, "", Some(&cookie)).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn search_warning_query_param_appears_in_body() {
+        let state =
+            build_test_state_full(MockKeycloak::default(), MockMas::default(), "secret", None)
+                .await;
+        let cookie = make_auth_cookie(TEST_CSRF);
+        let builder = Request::builder()
+            .method(Method::GET)
+            .uri("/users/search?warning=Needs+manual+cleanup")
+            .header("cookie", cookie);
+        let resp = reads_router(state)
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("Needs manual cleanup"));
     }
 
     #[tokio::test]

--- a/src/services/delete_user.rs
+++ b/src/services/delete_user.rs
@@ -7,6 +7,26 @@ use crate::{
     services::AuditService,
 };
 
+/// Result of the delete-user workflow.
+///
+/// A delete can complete in two ways:
+/// - `Deleted`: Keycloak was removed successfully.
+/// - `PartialFailure`: MAS was already deactivated, but the Keycloak delete
+///   failed and the admin must retry or reactivate manually.
+pub enum DeleteUserResult {
+    Deleted(WorkflowOutcome),
+    PartialFailure(WorkflowOutcome),
+}
+
+impl DeleteUserResult {
+    /// Return the workflow warnings collected while deleting the user.
+    pub fn outcome(&self) -> &WorkflowOutcome {
+        match self {
+            Self::Deleted(outcome) | Self::PartialFailure(outcome) => outcome,
+        }
+    }
+}
+
 /// Delete a user account from Keycloak and deactivate it in MAS.
 ///
 /// Steps:
@@ -14,7 +34,9 @@ use crate::{
 ///   2. Look up the MAS user by username (non-fatal if missing or unreachable).
 ///   3. Deactivate the MAS account (fatal — audit-logged; if this fails the
 ///      Keycloak record is preserved so the admin can retry).
-///   4. Delete the Keycloak user (fatal — audit-logged).
+///   4. Delete the Keycloak user (fatal unless MAS was already deactivated; in
+///      that case the workflow returns a partial-failure outcome with recovery
+///      guidance so the admin can retry or reactivate manually).
 pub async fn delete_user(
     keycloak_id: &str,
     keycloak: &dyn KeycloakIdentityProvider,
@@ -23,21 +45,26 @@ pub async fn delete_user(
     admin_subject: &str,
     admin_username: &str,
     homeserver_domain: &str,
-) -> Result<WorkflowOutcome, AppError> {
+) -> Result<DeleteUserResult, AppError> {
     let kc_user = keycloak.get_user(keycloak_id).await?;
     let username = &kc_user.username;
     let matrix_user_id = format!("@{}:{}", username, homeserver_domain);
+    let mut outcome = WorkflowOutcome::ok();
 
     // ── Deactivate MAS user first (if present) ────────────────────────────────
     // MAS is attempted before Keycloak so that if it fails the Keycloak record
     // is preserved and the admin can retry cleanly.
-    let mas_user = mas
-        .get_user_by_username(username)
-        .await
-        .unwrap_or_else(|e| {
+    let mas_user = match mas.get_user_by_username(username).await {
+        Ok(user) => user,
+        Err(e) => {
             tracing::warn!(error = %e, "MAS user lookup failed during delete; skipping MAS deactivation");
+            outcome.add_warning(
+                "Deleted the Keycloak user, but MAS lookup failed before cleanup. Check MAS for a leftover account."
+                    .to_string(),
+            );
             None
-        });
+        }
+    };
 
     if let Some(ref mas_user) = mas_user {
         let mas_result = mas.deactivate_user(&mas_user.id).await;
@@ -85,13 +112,24 @@ pub async fn delete_user(
             json!({
                 "keycloak_user_id": keycloak_id,
                 "username": username,
-                "mas_deleted": mas_user.is_some(),
+                "mas_deactivated": mas_user.is_some(),
             }),
         )
         .await?;
 
-    kc_result?;
-    Ok(WorkflowOutcome::ok())
+    if let Err(err) = kc_result {
+        if mas_user.is_some() {
+            outcome.add_warning(
+                "MAS was deactivated, but deleting the Keycloak user failed. Retry delete or reactivate the user before reinviting them."
+                    .to_string(),
+            );
+            return Ok(DeleteUserResult::PartialFailure(outcome));
+        }
+
+        return Err(err);
+    }
+
+    Ok(DeleteUserResult::Deleted(outcome))
 }
 
 #[cfg(test)]
@@ -268,7 +306,7 @@ mod tests {
         });
         let mas = Arc::new(MockMs::default());
 
-        delete_user(
+        let result = delete_user(
             "kc-1",
             kc.as_ref(),
             mas.as_ref(),
@@ -279,6 +317,7 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(!result.outcome().has_warnings());
 
         let logs = audit.for_user("kc-1", 10).await.unwrap();
         assert_eq!(logs.len(), 1);
@@ -298,7 +337,7 @@ mod tests {
             ..Default::default()
         });
 
-        delete_user(
+        let result = delete_user(
             "kc-1",
             kc.as_ref(),
             mas.as_ref(),
@@ -309,6 +348,7 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(!result.outcome().has_warnings());
 
         let logs = audit.for_user("kc-1", 10).await.unwrap();
         assert_eq!(logs.len(), 2);
@@ -351,7 +391,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_keycloak_failure_is_logged_and_returned() {
+    async fn delete_keycloak_failure_without_mas_deactivation_is_logged_and_returned() {
         let audit = audit_svc().await;
         let kc = Arc::new(MockKc {
             user: Some(kc_user("kc-1", "alice")),
@@ -377,18 +417,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_mas_lookup_failure_is_non_fatal() {
+    async fn delete_keycloak_failure_after_mas_deactivation_returns_partial_failure() {
         let audit = audit_svc().await;
         let kc = Arc::new(MockKc {
             user: Some(kc_user("kc-1", "alice")),
-            fail_delete: false,
+            fail_delete: true,
         });
         let mas = Arc::new(MockMs {
-            fail_lookup: true,
+            user: Some(mas_user("alice")),
             ..Default::default()
         });
 
-        delete_user(
+        let result = delete_user(
             "kc-1",
             kc.as_ref(),
             mas.as_ref(),
@@ -399,6 +439,52 @@ mod tests {
         )
         .await
         .unwrap();
+
+        let outcome = match result {
+            DeleteUserResult::PartialFailure(outcome) => outcome,
+            DeleteUserResult::Deleted(_) => panic!("expected partial failure"),
+        };
+        assert!(outcome.has_warnings());
+        assert!(outcome
+            .warning_summary()
+            .contains("MAS was deactivated, but deleting the Keycloak user failed"));
+
+        let logs = audit.for_user("kc-1", 10).await.unwrap();
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].action, "deactivate_mas_user");
+        assert_eq!(logs[0].result, "success");
+        assert_eq!(logs[1].action, "delete_keycloak_user");
+        assert_eq!(logs[1].result, "failure");
+    }
+
+    #[tokio::test]
+    async fn delete_mas_lookup_failure_is_non_fatal_and_surfaces_warning() {
+        let audit = audit_svc().await;
+        let kc = Arc::new(MockKc {
+            user: Some(kc_user("kc-1", "alice")),
+            fail_delete: false,
+        });
+        let mas = Arc::new(MockMs {
+            fail_lookup: true,
+            ..Default::default()
+        });
+
+        let result = delete_user(
+            "kc-1",
+            kc.as_ref(),
+            mas.as_ref(),
+            &audit,
+            "sub",
+            "admin",
+            "example.com",
+        )
+        .await
+        .unwrap();
+        assert!(result.outcome().has_warnings());
+        assert!(result
+            .outcome()
+            .warning_summary()
+            .contains("MAS lookup failed before cleanup"));
 
         // MAS lookup failed non-fatally — only the Keycloak delete is logged.
         let logs = audit.for_user("kc-1", 10).await.unwrap();

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -15,6 +15,11 @@
   <h1>User Search</h1>
 </div>
 
+{% match warning %}
+{% when Some with (msg) %}
+<div class="flash flash-warning">{{ msg }}</div>
+{% when None %}{% endmatch %}
+
 <div class="card">
   <form method="get" action="/users/search">
     <div class="search-row">


### PR DESCRIPTION
## Summary
- return an explicit partial-failure result when MAS deactivation succeeds but Keycloak deletion fails
- redirect delete failures with recovery guidance instead of dropping admins on a generic upstream error page
- surface successful deletes that skipped MAS cleanup because the MAS lookup failed

Closes #60.

## Verification
- flox activate -- cargo fmt --check
- flox activate -- cargo clippy --all-targets -- -D warnings
- flox activate -- cargo test