### PR TITLE
style: Pico CSS adoption and UX polish

### DIFF
--- a/src/handlers/audit.rs
+++ b/src/handlers/audit.rs
@@ -68,6 +68,7 @@ fn validate_optional_filter(
 struct AuditTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     logs: Vec<AuditRow>,
     page: i64,
     total_pages: i64,
@@ -140,6 +141,7 @@ pub async fn list(
     let html = AuditTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/audit".to_string(),
         logs: rows,
         page,
         total_pages,

--- a/src/handlers/bulk_reconcile.rs
+++ b/src/handlers/bulk_reconcile.rs
@@ -24,6 +24,7 @@ pub struct BulkReconcileForm {
 #[template(path = "bulk_reconcile_result.html")]
 struct BulkReconcileResultTemplate {
     username: String,
+    current_path: String,
     users_processed: usize,
     users_skipped: usize,
     warnings: Vec<String>,
@@ -141,6 +142,7 @@ pub async fn bulk_reconcile(
 
     let tmpl = BulkReconcileResultTemplate {
         username: admin.username,
+        current_path: "/".to_string(),
         users_processed,
         users_skipped,
         warnings,

--- a/src/handlers/dashboard.rs
+++ b/src/handlers/dashboard.rs
@@ -32,6 +32,7 @@ pub struct DashboardQuery {
 struct DashboardTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     total_users: u32,
     invites_24h: i64,
     invites_7d: i64,
@@ -116,6 +117,7 @@ pub async fn dashboard(
     let html = DashboardTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/".to_string(),
         total_users,
         invites_24h,
         invites_7d,

--- a/src/handlers/policy.rs
+++ b/src/handlers/policy.rs
@@ -21,6 +21,7 @@ use crate::{
 struct PolicyTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     bindings: Vec<PolicyBinding>,
     room_count: usize,
     synapse_enabled: bool,
@@ -102,6 +103,7 @@ pub async fn list(
     let html = PolicyTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/policy".to_string(),
         bindings,
         room_count,
         synapse_enabled,

--- a/src/handlers/templates.rs
+++ b/src/handlers/templates.rs
@@ -23,6 +23,7 @@ pub struct ListQuery {
 struct TemplatesTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     templates: Vec<OnboardingTemplate>,
     notice: Option<String>,
 }
@@ -37,6 +38,7 @@ pub async fn list(
     let html = TemplatesTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/templates".to_string(),
         templates,
         notice: query.notice,
     }

--- a/src/handlers/users.rs
+++ b/src/handlers/users.rs
@@ -28,6 +28,7 @@ pub struct SearchParams {
 struct SearchTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     query: String,
     warning: Option<String>,
     results: Vec<UnifiedUserSummary>,
@@ -56,6 +57,7 @@ pub async fn search(
     let html = SearchTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/users/search".to_string(),
         query,
         warning: params.warning,
         results,
@@ -81,6 +83,7 @@ pub struct DetailQuery {
 struct DetailTemplate {
     username: String,
     csrf_token: String,
+    current_path: String,
     user: UnifiedUserDetail,
     audit_logs: Vec<AuditEntry>,
     notice: Option<String>,
@@ -126,6 +129,7 @@ pub async fn detail(
     let html = DetailTemplate {
         username: admin.username,
         csrf_token: admin.csrf_token,
+        current_path: "/users".to_string(),
         user,
         audit_logs,
         notice: query.notice,

--- a/static/app.css
+++ b/static/app.css
@@ -1,47 +1,31 @@
-/* ── Reset & base ────────────────────────────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-body {
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  color: #1a1a1a;
-  background: #f5f5f5;
-  line-height: 1.5;
+/* ── CSS Custom Properties ───────────────────────────────────────────────── */
+:root {
+  --mia-header-bg: #1a1a2e;
+  --mia-accent: #0055cc;
+  --mia-danger: #c0392b;
+  --mia-success: #27ae60;
+  --mia-warning: #e67e22;
+  --mia-muted: #888;
 }
 
-a { color: #0055cc; text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-/* ── Nav ─────────────────────────────────────────────────────────────────── */
+/* ── Pico overrides for MIA branding ────────────────────────────────────── */
 header {
-  background: #1a1a2e;
+  background: var(--mia-header-bg);
+  --pico-color: #fff;
+}
+
+header nav a {
+  color: #ccc;
+}
+header nav a:hover {
   color: #fff;
-  padding: 0 1.5rem;
 }
-
-nav {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  height: 48px;
-}
-
-.brand {
+header nav [aria-current="page"] {
+  color: #fff;
   font-weight: 600;
-  font-size: 15px;
-  color: #fff;
-  margin-right: 1rem;
 }
-
-.nav-links { display: flex; gap: 1rem; flex: 1; }
-.nav-links a { color: #ccc; font-size: 13px; }
-.nav-links a:hover { color: #fff; text-decoration: none; }
-
-.nav-user { display: flex; align-items: center; gap: 0.75rem; color: #ccc; font-size: 13px; }
 
 /* ── Layout ──────────────────────────────────────────────────────────────── */
-main { max-width: 1100px; margin: 1.5rem auto; padding: 0 1.5rem; }
-
 .page-header { margin-bottom: 1.25rem; }
 .page-header h1 { font-size: 22px; font-weight: 600; }
 .page-header a { font-size: 13px; color: #555; display: block; margin-bottom: 0.25rem; }
@@ -56,49 +40,14 @@ main { max-width: 1100px; margin: 1.5rem auto; padding: 0 1.5rem; }
 
 .card h2 { font-size: 15px; font-weight: 600; margin-bottom: 1rem; }
 
-/* ── Tables ──────────────────────────────────────────────────────────────── */
-table { width: 100%; border-collapse: collapse; }
-th { text-align: left; font-size: 12px; font-weight: 600; color: #555; border-bottom: 1px solid #e0e0e0; padding: 0.5rem 0.75rem; }
-td { padding: 0.5rem 0.75rem; border-bottom: 1px solid #f0f0f0; vertical-align: top; }
-tr:last-child td { border-bottom: none; }
-tr:hover td { background: #fafafa; }
-
 code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3px; }
 
 /* ── Forms ───────────────────────────────────────────────────────────────── */
 .search-row { display: flex; gap: 0.5rem; }
-.search-row input[type=text] {
-  flex: 1;
-  padding: 0.4rem 0.75rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
-}
 
 .filter-row { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
-.filter-row input[type=text] { flex: 1; padding: 0.4rem 0.75rem; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
-.filter-row select { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
 
 /* ── Buttons ─────────────────────────────────────────────────────────────── */
-.btn {
-  display: inline-block;
-  padding: 0.4rem 0.9rem;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  border: none;
-  text-decoration: none;
-}
-
-.btn-primary { background: #0055cc; color: #fff; }
-.btn-primary:hover { background: #0044aa; color: #fff; text-decoration: none; }
-
-.btn-danger { background: #c0392b; color: #fff; }
-.btn-danger:hover { background: #a93226; color: #fff; text-decoration: none; }
-
-.btn-sm { padding: 0.25rem 0.6rem; font-size: 12px; }
-
 .btn-link {
   background: none;
   border: none;
@@ -120,13 +69,13 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
 .detail-list dd { }
 
 /* ── Misc ────────────────────────────────────────────────────────────────── */
-.muted { color: #888; font-size: 13px; }
-.badge-ok      { color: #27ae60; font-weight: 600; }
+.muted { color: var(--mia-muted); font-size: 13px; }
+.badge-ok      { color: var(--mia-success); font-weight: 600; }
 .badge-info    { color: #2980b9; font-weight: 600; }
-.badge-warning { color: #c0392b; font-weight: 600; }
+.badge-warning { color: var(--mia-danger); font-weight: 600; }
 
-.result-success { color: #27ae60; font-weight: 500; }
-.result-failure { color: #c0392b; font-weight: 500; }
+.result-success { color: var(--mia-success); font-weight: 500; }
+.result-failure { color: var(--mia-danger); font-weight: 500; }
 
 /* ── Flash messages ──────────────────────────────────────────────────────── */
 .flash { padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1rem; font-size: 14px; }
@@ -141,8 +90,8 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
 /* ── Stats grid ──────────────────────────────────────────────────────────── */
 .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.25rem; }
 .stat-card { background: #fff; border: 1px solid #e0e0e0; border-radius: 6px; padding: 1.25rem 1.5rem; text-align: center; }
-.stat-card .stat-value { font-size: 36px; font-weight: 700; color: #1a1a2e; line-height: 1; margin-bottom: 0.25rem; }
-.stat-card .stat-label { font-size: 12px; color: #888; text-transform: uppercase; letter-spacing: 0.05em; }
+.stat-card .stat-value { font-size: 36px; font-weight: 700; color: var(--mia-header-bg); line-height: 1; margin-bottom: 0.25rem; }
+.stat-card .stat-label { font-size: 12px; color: var(--mia-muted); text-transform: uppercase; letter-spacing: 0.05em; }
 
 /* ── Login ───────────────────────────────────────────────────────────────── */
 .login-page { display: flex; align-items: center; justify-content: center; min-height: 100vh; }
@@ -169,13 +118,13 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--muted, #888);
+  color: var(--mia-muted);
 }
 .status-value { font-weight: 600; }
-.status-sub { font-size: 0.8rem; color: var(--muted, #888); }
+.status-sub { font-size: 0.8rem; color: var(--mia-muted); }
 .status-ok .status-value { color: #2a9d3c; }
-.status-err .status-value { color: #c0392b; }
-.status-warn .status-value { color: #e67e22; }
+.status-err .status-value { color: var(--mia-danger); }
+.status-warn .status-value { color: var(--mia-warning); }
 
 /* ── Form layout ──────────────────────────────────────────────────────────── */
 
@@ -194,16 +143,6 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
   margin-bottom: 0.25rem;
   font-weight: 600;
   font-size: 12px;
-}
-
-.form-group select,
-.form-group input[type="text"],
-.form-group input[type="number"] {
-  width: 100%;
-  padding: 0.4rem 0.75rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
 }
 
 /* ── Alerts ───────────────────────────────────────────────────────────────── */
@@ -231,25 +170,9 @@ code { font-size: 12px; background: #f0f0f0; padding: 1px 4px; border-radius: 3p
 
 .action-buttons { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.5rem; }
 
-/* ── Confirmation dialogs ────────────────────────────────────────────────── */
-
-.confirm-dialog {
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  padding: 1.5rem;
-  max-width: 440px;
-  width: 90vw;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.15);
-}
-.confirm-dialog::backdrop { background: rgba(0,0,0,0.4); }
-.confirm-dialog h3 { font-size: 16px; font-weight: 600; margin-bottom: 0.75rem; }
-.confirm-dialog p { font-size: 14px; margin-bottom: 0.5rem; line-height: 1.5; }
-.confirm-dialog ul { font-size: 14px; margin: 0.5rem 0 0.75rem 1.25rem; line-height: 1.6; }
-.dialog-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
-
 /* ── Session display ─────────────────────────────────────────────────────── */
 
-.session-count { font-weight: 400; font-size: 13px; color: #888; }
+.session-count { font-weight: 400; font-size: 13px; color: var(--mia-muted); }
 .badge-muted { color: #999; font-weight: 500; }
 .hidden { display: none; }
 .toggle-finished { background: #f0f0f0; color: #555; }

--- a/templates/audit.html
+++ b/templates/audit.html
@@ -3,11 +3,13 @@
 {% block title %}Audit Log — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/audit.html
+++ b/templates/audit.html
@@ -47,7 +47,9 @@
   {% if logs.is_empty() %}
     <p class="muted">No audit entries yet.</p>
   {% else %}
+    <figure>
     <table>
+      <caption>Audit log entries</caption>
       <thead>
         <tr>
           <th>Time</th>
@@ -77,6 +79,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </figure>
   {% endif %}
 </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,29 +1,32 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Matrix Identity Admin{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <link rel="stylesheet" href="/static/app.css">
 </head>
 <body>
   <header>
     <nav>
-      <span class="brand">Matrix Identity Admin</span>
-      <div class="nav-links">
-        <a href="/">Dashboard</a>
-        <a href="/users/search">Users</a>
-        <a href="/policy">Policy</a>
-        <a href="/templates">Templates</a>
-        <a href="/audit">Audit Log</a>
-      </div>
-      <div class="nav-user">
+      <ul>
+        <li><strong>Matrix Identity Admin</strong></li>
+      </ul>
+      <ul>
+        <li><a href="/" {% if current_path == "/" %}aria-current="page"{% endif %}>Dashboard</a></li>
+        <li><a href="/users/search" {% if current_path.starts_with("/users") %}aria-current="page"{% endif %}>Users</a></li>
+        <li><a href="/policy" {% if current_path.starts_with("/policy") %}aria-current="page"{% endif %}>Policy</a></li>
+        <li><a href="/templates" {% if current_path == "/templates" %}aria-current="page"{% endif %}>Templates</a></li>
+        <li><a href="/audit" {% if current_path.starts_with("/audit") %}aria-current="page"{% endif %}>Audit Log</a></li>
+      </ul>
+      <ul>
         {% block nav_user %}{% endblock %}
-      </div>
+      </ul>
     </nav>
   </header>
 
-  <main>
+  <main class="container">
     {% block content %}{% endblock %}
   </main>
   <script src="/static/htmx.min.js"></script>

--- a/templates/bulk_reconcile_result.html
+++ b/templates/bulk_reconcile_result.html
@@ -3,7 +3,7 @@
 {% block title %}Bulk Reconcile Results — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
+  <li>{{ username }}</li>
 {% endblock %}
 
 {% block content %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -91,26 +91,29 @@
   {% if recent_actions.is_empty() %}
     <p class="muted">No recent actions.</p>
   {% else %}
-    <table>
-      <thead>
-        <tr>
-          <th>Time</th>
-          <th>Admin</th>
-          <th>Action</th>
-          <th>Result</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for action in recent_actions %}
-        <tr>
-          <td><a href="/audit">{{ action.timestamp }}</a></td>
-          <td>{{ action.admin_username }}</td>
-          <td>{{ action.action }}</td>
-          <td class="result-{{ action.result }}">{{ action.result }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <figure>
+      <table>
+        <caption>Recent admin actions</caption>
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Admin</th>
+            <th>Action</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for action in recent_actions %}
+          <tr>
+            <td><a href="/audit">{{ action.timestamp }}</a></td>
+            <td>{{ action.admin_username }}</td>
+            <td>{{ action.action }}</td>
+            <td class="result-{{ action.result }}">{{ action.result }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </figure>
     <p><a href="/audit">View full audit log →</a></p>
   {% endif %}
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -43,6 +43,7 @@
   </div>
 </div>
 
+<div aria-live="polite">
 {% match notice %}
 {% when Some with (msg) %}
 <div class="flash flash-notice">{{ msg }}</div>
@@ -51,6 +52,7 @@
 {% when Some with (msg) %}
 <div class="flash flash-error">{{ msg }}</div>
 {% when None %}{% endmatch %}
+</div>
 
 <div class="card">
   <h2>Invite User</h2>
@@ -78,11 +80,19 @@
 {% if synapse_enabled %}
 <div class="card" style="margin-top:1rem">
   <h2>Bulk Actions</h2>
-  <form method="post" action="/users/reconcile/all"
-        onsubmit="return confirm('Reconcile room membership for ALL enabled users? This may take a while.')">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn btn-primary">Reconcile All Users</button>
-  </form>
+  <button type="button" class="btn btn-primary" onclick="document.getElementById('dlg-bulk-reconcile').showModal()">Reconcile All Users</button>
+
+  <dialog id="dlg-bulk-reconcile" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-bulk-title">
+    <h3 id="dlg-bulk-title">Bulk Reconcile</h3>
+    <p>This will reconcile room membership for <strong>all enabled users</strong>. This may take a while for large user bases.</p>
+    <div class="dialog-actions">
+      <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
+      <form method="post" action="/users/reconcile/all">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+        <button type="submit" class="btn btn-primary">Reconcile All</button>
+      </form>
+    </div>
+  </dialog>
 </div>
 {% endif %}
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,11 +3,13 @@
 {% block title %}Dashboard — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Error {{ status }} — Matrix Identity Admin</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <link rel="stylesheet" href="/static/app.css">
 </head>
 <body>
-  <main style="max-width:600px;margin:4rem auto;padding:1rem">
+  <main class="container" style="margin-top:4rem">
     <h1>Error {{ status }}</h1>
     <p>{{ message }}</p>
     <a href="/">Go to dashboard</a>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sign In — Matrix Identity Admin</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <link rel="stylesheet" href="/static/app.css">
 </head>
 <body class="login-page">
-  <main class="login-box">
-    <h1>Matrix Identity Admin</h1>
-    <p>Sign in with your Keycloak admin account.</p>
-    <a href="/auth/login" class="btn btn-primary">Sign in with Keycloak</a>
+  <main class="container">
+    <article class="login-box">
+      <h1>Matrix Identity Admin</h1>
+      <p>Sign in with your Keycloak admin account.</p>
+      <a href="/auth/login" role="button">Sign in with Keycloak</a>
+    </article>
   </main>
 </body>
 </html>

--- a/templates/policy.html
+++ b/templates/policy.html
@@ -30,7 +30,9 @@
   {% if bindings.is_empty() %}
     <p class="muted">No policy bindings configured yet.</p>
   {% else %}
+    <figure>
     <table>
+      <caption>Policy bindings</caption>
       <thead>
         <tr>
           <th>Subject</th>
@@ -74,6 +76,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </figure>
   {% endif %}
 </div>
 

--- a/templates/policy.html
+++ b/templates/policy.html
@@ -18,12 +18,14 @@
   <p class="muted">Map Keycloak groups and roles to Matrix rooms and spaces.</p>
 </div>
 
+<div aria-live="polite">
 {% if !notice.is_empty() %}
 <div class="alert alert-success">{{ notice }}</div>
 {% endif %}
 {% if !warning.is_empty() %}
 <div class="alert alert-warning">{{ warning }}</div>
 {% endif %}
+</div>
 
 <div class="card">
   <h2>Current Bindings</h2>

--- a/templates/policy.html
+++ b/templates/policy.html
@@ -3,11 +3,13 @@
 {% block title %}Policy — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/reconcile_preview.html
+++ b/templates/reconcile_preview.html
@@ -50,10 +50,19 @@
   {% endif %}
 
   {% if !joins.is_empty() || !kicks.is_empty() %}
-  <form method="post" action="/users/{{ keycloak_id }}/reconcile" style="margin-top:1rem"
-        onsubmit="return confirm('Apply these changes now?')">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn btn-primary">Confirm and Run</button>
-  </form>
+  <button type="button" class="btn btn-primary" style="margin-top:1rem"
+          onclick="document.getElementById('dlg-confirm-reconcile').showModal()">Confirm and Run</button>
+
+  <dialog id="dlg-confirm-reconcile" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-confirm-reconcile-title">
+    <h3 id="dlg-confirm-reconcile-title">Apply Changes</h3>
+    <p>Apply the previewed membership changes now?</p>
+    <div class="dialog-actions">
+      <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
+      <form method="post" action="/users/{{ keycloak_id }}/reconcile">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+        <button type="submit" class="btn btn-primary">Apply Changes</button>
+      </form>
+    </div>
+  </dialog>
   {% endif %}
 </div>

--- a/templates/status_card.html
+++ b/templates/status_card.html
@@ -1,16 +1,16 @@
 <div class="status-grid">
   <div class="status-item {% if keycloak_ok %}status-ok{% else %}status-err{% endif %}">
     <span class="status-label">Keycloak</span>
-    <span class="status-value">{% if keycloak_ok %}&#9679;  reachable{% else %}&#9679;  unreachable{% endif %}</span>
+    <span class="status-value">{% if keycloak_ok %}<span aria-hidden="true">&#9679;</span>  reachable{% else %}<span aria-hidden="true">&#9679;</span>  unreachable{% endif %}</span>
     {% if let Some(n) = user_count %}<span class="status-sub">{{ n }} users</span>{% endif %}
   </div>
   <div class="status-item {% if mas_ok %}status-ok{% else %}status-err{% endif %}">
     <span class="status-label">MAS</span>
-    <span class="status-value">{% if mas_ok %}&#9679;  reachable{% else %}&#9679;  unreachable{% endif %}</span>
+    <span class="status-value">{% if mas_ok %}<span aria-hidden="true">&#9679;</span>  reachable{% else %}<span aria-hidden="true">&#9679;</span>  unreachable{% endif %}</span>
   </div>
   <div class="status-item {% if synapse_configured %}status-ok{% else %}status-warn{% endif %}">
     <span class="status-label">Synapse</span>
-    <span class="status-value">{% if synapse_configured %}&#9679;  configured{% else %}&#9679;  not configured{% endif %}</span>
+    <span class="status-value">{% if synapse_configured %}<span aria-hidden="true">&#9679;</span>  configured{% else %}<span aria-hidden="true">&#9679;</span>  not configured{% endif %}</span>
     {% if let Some(n) = room_count %}<span class="status-sub">{{ n }} rooms</span>{% endif %}
   </div>
 </div>

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -56,7 +56,9 @@
   {% if templates.is_empty() %}
     <p class="muted">No onboarding templates defined.</p>
   {% else %}
+    <figure>
     <table>
+      <caption>Onboarding templates</caption>
       <thead>
         <tr>
           <th>Name</th>
@@ -85,6 +87,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </figure>
   {% endif %}
 </div>
 {% endblock %}

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -3,11 +3,13 @@
 {% block title %}Onboarding Templates — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -13,10 +13,12 @@
 {% endblock %}
 
 {% block content %}
+<div aria-live="polite">
 {% match notice %}
 {% when Some with (msg) %}
 <div class="flash flash-notice">{{ msg }}</div>
 {% when None %}{% endmatch %}
+</div>
 
 <div class="page-header">
   <h1>Onboarding Templates</h1>
@@ -76,18 +78,35 @@
           <td>{{ tmpl.groups.join(", ") }}</td>
           <td>{{ tmpl.roles.join(", ") }}</td>
           <td>
-            <form method="post" action="/templates/delete"
-                  onsubmit="return confirm('Delete template ' + this.dataset.name + '?')" data-name="{{ tmpl.name }}">
-              <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-              <input type="hidden" name="name" value="{{ tmpl.name }}">
-              <button type="submit" class="btn btn-danger btn-sm">Delete</button>
-            </form>
+            <button type="button" class="btn btn-danger btn-sm"
+                    onclick="openDeleteTemplateDialog('{{ tmpl.name }}')">Delete</button>
           </td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
     </figure>
+
+    <dialog id="dlg-delete-template" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-del-tmpl-title">
+      <h3 id="dlg-del-tmpl-title">Delete Template</h3>
+      <p>Delete template <strong id="del-tmpl-name"></strong>? This cannot be undone.</p>
+      <div class="dialog-actions">
+        <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
+        <form id="delete-template-form" method="post" action="/templates/delete">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+          <input type="hidden" name="name" id="del-tmpl-input" value="">
+          <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+      </div>
+    </dialog>
+
+    <script>
+    function openDeleteTemplateDialog(name) {
+      document.getElementById('del-tmpl-name').textContent = name;
+      document.getElementById('del-tmpl-input').value = name;
+      document.getElementById('dlg-delete-template').showModal();
+    }
+    </script>
   {% endif %}
 </div>
 {% endblock %}

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -3,11 +3,13 @@
 {% block title %}{{ user.username }} — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block content %}
+<div aria-live="polite">
 {% match notice %}
 {% when Some with (msg) %}
 <div class="flash flash-notice">{{ msg }}</div>
@@ -21,6 +22,7 @@
 {% when Some with (msg) %}
 <div class="flash flash-warning">{{ msg }}</div>
 {% when None %}{% endmatch %}
+</div>
 
 <div class="page-header">
   <a href="/users/search">← Back to search</a>
@@ -79,8 +81,8 @@
 <!-- Confirmation dialogs -->
 {% match user.lifecycle_state %}
 {% when crate::models::unified::LifecycleState::Active %}
-<dialog id="dlg-logout" class="confirm-dialog">
-  <h3>Force Keycloak Logout</h3>
+<dialog id="dlg-logout" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-logout-title">
+  <h3 id="dlg-logout-title">Force Keycloak Logout</h3>
   <p>This will terminate all active Keycloak sessions for <strong>{{ user.username }}</strong>. The user will need to log in again.</p>
   <div class="dialog-actions">
     <button type="button" class="btn" onclick="this.closest('dialog').close()">Cancel</button>
@@ -91,8 +93,8 @@
   </div>
 </dialog>
 
-<dialog id="dlg-disable" class="confirm-dialog">
-  <h3>Disable User</h3>
+<dialog id="dlg-disable" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-disable-title">
+  <h3 id="dlg-disable-title">Disable User</h3>
   <p>This will:</p>
   <ul>
     <li>Revoke all active MAS sessions</li>
@@ -109,8 +111,8 @@
   </div>
 </dialog>
 
-<dialog id="dlg-offboard" class="confirm-dialog">
-  <h3>Offboard User</h3>
+<dialog id="dlg-offboard" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-offboard-title">
+  <h3 id="dlg-offboard-title">Offboard User</h3>
   <p>This will:</p>
   <ul>
     <li>Revoke all active MAS sessions</li>
@@ -128,8 +130,8 @@
   </div>
 </dialog>
 {% when crate::models::unified::LifecycleState::Disabled %}
-<dialog id="dlg-reactivate" class="confirm-dialog">
-  <h3>Reactivate User</h3>
+<dialog id="dlg-reactivate" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-reactivate-title">
+  <h3 id="dlg-reactivate-title">Reactivate User</h3>
   <p>This will re-enable the Keycloak account and reactivate the MAS account for <strong>{{ user.username }}</strong>. The user will be able to log in again.</p>
   <div class="dialog-actions">
     <button type="button" class="btn" onclick="this.closest('dialog').close()">Cancel</button>
@@ -142,8 +144,8 @@
 {% when crate::models::unified::LifecycleState::Invited %}
 {% endmatch %}
 
-<dialog id="dlg-delete" class="confirm-dialog">
-  <h3>Delete User</h3>
+<dialog id="dlg-delete" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-delete-title">
+  <h3 id="dlg-delete-title">Delete User</h3>
   <p>This will <strong>permanently delete</strong> <strong>{{ user.username }}</strong> from Keycloak and MAS.</p>
   <p><strong>This cannot be undone.</strong></p>
   <div class="dialog-actions">
@@ -156,8 +158,8 @@
 </dialog>
 
 {% if synapse_enabled %}
-<dialog id="dlg-reconcile" class="confirm-dialog">
-  <h3>Reconcile Room Membership</h3>
+<dialog id="dlg-reconcile" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-reconcile-title">
+  <h3 id="dlg-reconcile-title">Reconcile Room Membership</h3>
   <p>This will apply group policy for <strong>{{ user.username }}</strong>, force-joining or kicking from Matrix rooms as needed.</p>
   <div class="dialog-actions">
     <button type="button" class="btn" onclick="this.closest('dialog').close()">Cancel</button>
@@ -210,13 +212,8 @@
             </td>
             <td>
               {% if session.state == "active" %}
-              <form method="post"
-                    action="/users/{{ user.keycloak_id }}/sessions/{{ session.id }}/revoke"
-                    onsubmit="return confirm('Revoke this session?')">
-                <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-                <input type="hidden" name="session_type" value="{{ session.session_type }}">
-                <button type="submit" class="btn btn-danger btn-sm">Revoke</button>
-              </form>
+              <button type="button" class="btn btn-danger btn-sm"
+                      onclick="openRevokeDialog('{{ session.id }}', '{{ session.session_type }}')">Revoke</button>
               {% endif %}
             </td>
           </tr>
@@ -227,6 +224,19 @@
     {% if finished_session_count > 0 %}
     <button type="button" class="btn btn-sm toggle-finished" onclick="toggleFinished(this)" style="margin-top:0.5rem">Show {{ finished_session_count }} finished</button>
     {% endif %}
+
+    <dialog id="dlg-revoke-session" class="confirm-dialog" role="alertdialog" aria-labelledby="dlg-revoke-title">
+      <h3 id="dlg-revoke-title">Revoke Session</h3>
+      <p>This will immediately terminate this session. The user will need to log in again.</p>
+      <div class="dialog-actions">
+        <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
+        <form id="revoke-session-form" method="post" action="">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+          <input type="hidden" name="session_type" id="revoke-session-type" value="">
+          <button type="submit" class="btn btn-danger">Revoke Session</button>
+        </form>
+      </div>
+    </dialog>
   {% endif %}
 </div>
 
@@ -258,6 +268,12 @@
 </div>
 
 <script>
+function openRevokeDialog(sessionId, sessionType) {
+  var form = document.getElementById('revoke-session-form');
+  form.action = '/users/{{ user.keycloak_id }}/sessions/' + sessionId + '/revoke';
+  document.getElementById('revoke-session-type').value = sessionType;
+  document.getElementById('dlg-revoke-session').showModal();
+}
 function toggleFinished(btn) {
   var rows = document.querySelectorAll('.session-finished');
   var showing = rows.length > 0 && !rows[0].classList.contains('hidden');

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -173,11 +173,13 @@
 
 <!-- Sessions -->
 <div class="card">
-  <h2>MAS Sessions
-    {% if !user.sessions.is_empty() %}
-      <span class="session-count">({{ active_session_count }} active{% if finished_session_count > 0 %}, {{ finished_session_count }} finished{% endif %})</span>
-    {% endif %}
-  </h2>
+  <details open>
+    <summary>
+      MAS Sessions
+      {% if !user.sessions.is_empty() %}
+        <span class="session-count">({{ active_session_count }} active{% if finished_session_count > 0 %}, {{ finished_session_count }} finished{% endif %})</span>
+      {% endif %}
+    </summary>
   {% if user.sessions.is_empty() %}
     <p class="muted">No sessions found.</p>
   {% else %}
@@ -238,11 +240,13 @@
       </div>
     </dialog>
   {% endif %}
+  </details>
 </div>
 
 <!-- Audit -->
 <div class="card">
-  <h2>Recent Admin Actions</h2>
+  <details>
+    <summary>Recent Admin Actions</summary>
   {% if audit_logs.is_empty() %}
     <p class="muted">No admin actions recorded for this user.</p>
   {% else %}
@@ -265,6 +269,7 @@
       </table>
     </figure>
   {% endif %}
+  </details>
 </div>
 
 <script>

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -179,48 +179,51 @@
   {% if user.sessions.is_empty() %}
     <p class="muted">No sessions found.</p>
   {% else %}
-    <table>
-      <thead>
-        <tr>
-          <th>Session ID</th>
-          <th>Type</th>
-          <th>Created</th>
-          <th>Last Active</th>
-          <th>IP</th>
-          <th>State</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for session in user.sessions %}
-        <tr{% if session.state == "finished" %} class="session-finished"{% endif %}>
-          <td><code>{{ session.id }}</code></td>
-          <td>{{ session.session_type }}</td>
-          <td>{{ session.created_at.as_deref().unwrap_or("—") }}</td>
-          <td>{{ session.last_active_at.as_deref().unwrap_or("—") }}</td>
-          <td>{{ session.ip_address.as_deref().unwrap_or("—") }}</td>
-          <td>
-            {% if session.state == "active" %}
-              <span class="badge-ok">Active</span>
-            {% else %}
-              <span class="badge-muted">Finished</span>
-            {% endif %}
-          </td>
-          <td>
-            {% if session.state == "active" %}
-            <form method="post"
-                  action="/users/{{ user.keycloak_id }}/sessions/{{ session.id }}/revoke"
-                  onsubmit="return confirm('Revoke this session?')">
-              <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-              <input type="hidden" name="session_type" value="{{ session.session_type }}">
-              <button type="submit" class="btn btn-danger btn-sm">Revoke</button>
-            </form>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <figure>
+      <table>
+        <caption>MAS sessions</caption>
+        <thead>
+          <tr>
+            <th>Session ID</th>
+            <th>Type</th>
+            <th>Created</th>
+            <th>Last Active</th>
+            <th>IP</th>
+            <th>State</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for session in user.sessions %}
+          <tr{% if session.state == "finished" %} class="session-finished"{% endif %}>
+            <td><code>{{ session.id }}</code></td>
+            <td>{{ session.session_type }}</td>
+            <td>{{ session.created_at.as_deref().unwrap_or("—") }}</td>
+            <td>{{ session.last_active_at.as_deref().unwrap_or("—") }}</td>
+            <td>{{ session.ip_address.as_deref().unwrap_or("—") }}</td>
+            <td>
+              {% if session.state == "active" %}
+                <span class="badge-ok">Active</span>
+              {% else %}
+                <span class="badge-muted">Finished</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if session.state == "active" %}
+              <form method="post"
+                    action="/users/{{ user.keycloak_id }}/sessions/{{ session.id }}/revoke"
+                    onsubmit="return confirm('Revoke this session?')">
+                <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+                <input type="hidden" name="session_type" value="{{ session.session_type }}">
+                <button type="submit" class="btn btn-danger btn-sm">Revoke</button>
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </figure>
     {% if finished_session_count > 0 %}
     <button type="button" class="btn btn-sm toggle-finished" onclick="toggleFinished(this)" style="margin-top:0.5rem">Show {{ finished_session_count }} finished</button>
     {% endif %}
@@ -233,21 +236,24 @@
   {% if audit_logs.is_empty() %}
     <p class="muted">No admin actions recorded for this user.</p>
   {% else %}
-    <table>
-      <thead>
-        <tr><th>Time</th><th>Admin</th><th>Action</th><th>Result</th></tr>
-      </thead>
-      <tbody>
-        {% for log in audit_logs %}
-        <tr>
-          <td>{{ log.timestamp }}</td>
-          <td>{{ log.admin_username }}</td>
-          <td>{{ log.action }}</td>
-          <td class="result-{{ log.result }}">{{ log.result }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <figure>
+      <table>
+        <caption>Admin actions for this user</caption>
+        <thead>
+          <tr><th>Time</th><th>Admin</th><th>Action</th><th>Result</th></tr>
+        </thead>
+        <tbody>
+          {% for log in audit_logs %}
+          <tr>
+            <td>{{ log.timestamp }}</td>
+            <td>{{ log.admin_username }}</td>
+            <td>{{ log.action }}</td>
+            <td class="result-{{ log.result }}">{{ log.result }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </figure>
   {% endif %}
 </div>
 

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -36,30 +36,33 @@
   {% if results.is_empty() %}
     <p class="muted">No users found for <strong>{{ query }}</strong>.</p>
   {% else %}
-    <table>
-      <thead>
-        <tr>
-          <th>Username</th>
-          <th>Email</th>
-          <th>Matrix ID</th>
-          <th>Status</th>
-          <th>Correlation</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for user in results %}
-        <tr>
-          <td>{{ user.username }}</td>
-          <td>{{ user.email.as_deref().unwrap_or("—") }}</td>
-          <td>{{ user.inferred_matrix_id.as_deref().unwrap_or("—") }}</td>
-          <td><span class="{{ user.lifecycle_state.css_class() }}">{{ user.lifecycle_state }}</span></td>
-          <td>{{ user.correlation_status }}</td>
-          <td><a href="/users/{{ user.keycloak_id }}">View →</a></td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <figure>
+      <table>
+        <caption>Search results</caption>
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Email</th>
+            <th>Matrix ID</th>
+            <th>Status</th>
+            <th>Correlation</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for user in results %}
+          <tr>
+            <td>{{ user.username }}</td>
+            <td>{{ user.email.as_deref().unwrap_or("—") }}</td>
+            <td>{{ user.inferred_matrix_id.as_deref().unwrap_or("—") }}</td>
+            <td><span class="{{ user.lifecycle_state.css_class() }}">{{ user.lifecycle_state }}</span></td>
+            <td>{{ user.correlation_status }}</td>
+            <td><a href="/users/{{ user.keycloak_id }}">View →</a></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </figure>
   {% endif %}
 </div>
 

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -3,11 +3,13 @@
 {% block title %}User Search — Matrix Identity Admin{% endblock %}
 
 {% block nav_user %}
-  <span>{{ username }}</span>
-  <form method="post" action="/auth/logout" style="display:inline">
-    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-    <button type="submit" class="btn-link">Sign out</button>
-  </form>
+  <li>{{ username }}</li>
+  <li>
+    <form method="post" action="/auth/logout" style="display:inline">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      <button type="submit" class="outline secondary btn-link">Sign out</button>
+    </form>
+  </li>
 {% endblock %}
 
 {% block content %}

--- a/templates/users_search.html
+++ b/templates/users_search.html
@@ -17,10 +17,12 @@
   <h1>User Search</h1>
 </div>
 
+<div aria-live="polite">
 {% match warning %}
 {% when Some with (msg) %}
 <div class="flash flash-warning">{{ msg }}</div>
 {% when None %}{% endmatch %}
+</div>
 
 <div class="card">
   <form method="get" action="/users/search">


### PR DESCRIPTION
## Summary
- Add Pico CSS as base stylesheet with active nav indicator, trim app.css to MIA-specific rules only
- Wrap all tables in `<figure>` for responsive horizontal scroll on mobile
- Add ARIA attributes (aria-live, aria-hidden, role=alertdialog, aria-labelledby) across all templates
- Replace all `confirm()` calls with native `<dialog>` modals (session revoke, bulk reconcile, template delete, reconcile preview)
- Wrap sessions and audit sections in collapsible `<details>/<summary>` on user detail page

## Test Plan
- [ ] Verify all pages render correctly with Pico CSS at desktop and mobile widths
- [ ] Check active nav indicator highlights correct page on each route
- [ ] Test all confirmation dialogs open/close/submit correctly
- [ ] Verify tables scroll horizontally on narrow viewports
- [ ] Confirm sessions section opens by default, audit section collapsed
- [ ] Screen reader check: flash messages announced, decorative bullets hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)